### PR TITLE
feat: deployment improvements and Browserless.io stealth support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ HEADLESS_BROWSER=false                          # false=minimized window, true=f
 CHROME_PATH=                                    # Optional: override Chrome executable path
 BROWSERLESS_API_KEY=your_browserless_api_key   # Required when USE_LOCAL_BROWSER=false
 BROWSERLESS_ENDPOINT=wss://chrome.browserless.io
+BROWSERLESS_STEALTH=true                        # Use /chromium/stealth to prevent CAPTCHAs (default: true)
+BROWSERLESS_PROXY=                              # Optional: 'residential' for better IP reputation (slower)
 
 # Stripe - Payment processing
 STRIPE_SECRET_KEY=sk_test_xxx


### PR DESCRIPTION
## Summary
- Add Browserless.io stealth route support (`/chromium/stealth`) to prevent CAPTCHA detection during TradingView login
- Add `BROWSERLESS_STEALTH` env var (default: true) and `BROWSERLESS_PROXY` for proxy configuration
- Persist TradingView service account session to Redis for cross-instance sharing
- Add Fly.io deployment configuration with GitHub Actions CI/CD
- Add Dockerfile for containerized production deployment

## Test plan
- [ ] Deploy to Fly.io and verify logs show `🌐 Connecting to Browserless.io (stealth)...`
- [ ] Test TradingView login succeeds without CAPTCHA detection
- [ ] Verify session persistence works across deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)