### PR TITLE
Performance: reduce TradingView validate+publish hot-path latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ todos.json
 progress.json
 status.json
 logs/
+
+# Workflow reference screenshots (not for version control)
+docs/workflow-screenshots/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,47 @@ Reference these notes for:
 - Prior decisions and rationale
 - Setup changes and configurations
 - Completed tasks and their context
+
+## TradingView Automation Notes
+
+### Critical: /pine/ vs /chart/ Page Differences
+
+**The "Publish script" option ONLY exists on the /chart/ page, NOT on /pine/.**
+
+The script name dropdown on `/pine/` page contains:
+- Save script (Ctrl + S)
+- Make a copy…
+- Rename…
+- Version history…
+- Convert code to v6…
+- Create new
+- Open script… (Ctrl + O)
+
+**NO Publish option exists in this menu.**
+
+The "Publish script" button is only available in the **Pine Editor toolbar on the /chart/ page**. To publish a script:
+1. Navigate to `/chart/` (not `/pine/`)
+2. Open the Pine Editor panel (click Pine button in bottom toolbar)
+3. The "Publish script" button appears in the Pine Editor's own toolbar
+
+### Workflow Implications
+- **Validation**: Can be done on `/pine/` page (has "Add to chart" button)
+- **Publishing**: MUST be done on `/chart/` page (has "Publish script" button in Pine Editor toolbar)
+
+This is why the combined validation+publish flow navigates between pages.
+
+### Known Issue: Opening Pine Editor on /chart/
+
+When navigating to a fresh `/chart/` page, the Pine Editor panel is NOT open by default.
+Attempts to open it have been problematic:
+
+- `button[aria-label="Pine"]` - May navigate AWAY from `/chart/` to `/pine/` (page reload)
+- `[data-name="open-pine-editor"]` - Not found on fresh `/chart/` page
+- Keyboard shortcuts (Alt+P, Ctrl+,) - Not effective
+
+The Pine Editor only appears reliably when:
+1. You navigate from `/pine/` via "Add to chart" (preserves script context)
+2. You use a pre-warmed session that already has Pine Editor open
+3. You click on an existing indicator legend on the chart
+
+This is why the publish flow may fail with "Monaco editor not found".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,12 @@ Reference these notes for:
 | Feature | /pine/ Page | /chart/ Page |
 |---------|-------------|--------------|
 | Validate script | ✅ Yes | ✅ Yes |
-| Add to chart | ✅ Yes | ✅ Yes |
+| Add to chart | ❌ NO (button not present) | ✅ Yes |
 | **Publish script** | ❌ NO | ✅ **YES** |
 | Has canvas element | ✅ Yes (mini preview) | ✅ Yes (full chart) |
 | Has Monaco editor | ✅ Yes (fullscreen) | ✅ Yes (in panel) |
+
+**2026-01-27 Finding**: The "Add to chart" button does NOT exist on `/pine/` page (confirmed via Playwright, logged in). This means the `/pine/` → "Add to chart" → `/chart/` navigation path documented in the code is not viable. The only reliable ways to get Pine Editor open on `/chart/` are: (1) warm session pre-warmed at startup, or (2) clicking an existing indicator legend.
 
 **Common Pitfall**: The `/pine/` page has a canvas element (mini chart preview), which can trick code into thinking it's on the chart page. ALWAYS check the URL contains `/chart/` before attempting to publish.
 
@@ -65,23 +67,95 @@ The "Publish script" button is ONLY available in the **Pine Editor toolbar on th
 3. The "Publish script" button appears in the Pine Editor's own toolbar
 
 ### Workflow Summary
-- **Validation**: `/pine/` page (fast, has "Add to chart")
+- **Validation**: `/pine/` page for compile checks only (faster load, no "Add to chart")
 - **Publishing**: MUST navigate to `/chart/` page (has "Publish script" button)
 
-The combined validation+publish flow MUST navigate from /pine/ to /chart/ after validation.
+Combined validation+publish paths should prefer staying on `/chart/` end-to-end to avoid unstable cross-page transitions.
 
-### Known Issue: Opening Pine Editor on /chart/
+### Opening Pine Editor on /chart/
 
 When navigating to a fresh `/chart/` page, the Pine Editor panel is NOT open by default.
-Attempts to open it have been problematic:
 
-- `button[aria-label="Pine"]` - May navigate AWAY from `/chart/` to `/pine/` (page reload)
-- `[data-name="open-pine-editor"]` - Not found on fresh `/chart/` page
+**Working selectors:**
+- `[data-name="pine-dialog-button"]` (sidebar toggle) - WORKS, opens Pine Editor panel on `/chart/` without navigating away
+- `[data-name="open-pine-editor"]` - Only exists after Pine Editor has been opened once in the session
+
+**Non-working approaches:**
 - Keyboard shortcuts (Alt+P, Ctrl+,) - Not effective
 
-The Pine Editor only appears reliably when:
-1. You navigate from `/pine/` via "Add to chart" (preserves script context)
-2. You use a pre-warmed session that already has Pine Editor open
-3. You click on an existing indicator legend on the chart
+The code tries `open-pine-editor` first (works on pre-warmed sessions), then falls back to `pine-dialog-button` (works on fresh `/chart/` pages).
 
-This is why the publish flow may fail with "Monaco editor not found".
+## Local Testing with Warm Browser
+
+### Setup
+
+To debug the TradingView automation locally with a visible Chrome browser:
+
+```bash
+# Start dev server with local warm browser (Chrome with GUI)
+USE_WARM_LOCAL_BROWSER=true npm run dev
+```
+
+This will:
+1. Launch a visible Chrome window
+2. Auto-login to TradingView using credentials from Redis
+3. Navigate to the chart page and open Pine Editor
+4. Keep the browser warm for validation requests
+
+### Connecting Playwright MCP for Debugging
+
+1. Get the Chrome debug port:
+   ```bash
+   cat /tmp/puppeteer_dev_chrome_profile-*/DevToolsActivePort | head -1
+   ```
+
+2. View Chrome's debug info:
+   ```
+   http://localhost:<port>/json
+   ```
+
+3. Use Playwright MCP to interact with the local web app:
+   ```
+   Navigate to: http://localhost:3000
+   ```
+
+### Debugging the Publish Dialog
+
+When debugging publish dialog issues:
+
+1. Start the dev server with `USE_WARM_LOCAL_BROWSER=true`
+2. Navigate to `http://localhost:3000` in Playwright
+3. Submit a validation request
+4. Watch the Chrome window to see the TradingView publish dialog
+5. Check terminal output for `[Warm Validate]` logs
+
+### Key Differences: Local vs Production
+
+| Aspect | Local | Production (Fly.io) |
+|--------|-------|---------------------|
+| Browser | Chrome with GUI | Headless Chromium |
+| Visibility | Can see dialogs | Screenshots only |
+| Performance | Faster | Network latency |
+| Debugging | Real-time observation | Log analysis |
+
+### Common Debug Patterns
+
+**Dialog fill timeout**: If the dialog fill times out locally, check:
+- Is the dialog actually visible in Chrome?
+- Are the selectors finding the correct elements?
+- Is TradingView showing any overlay/modal blocking the dialog?
+
+**Script lookup issues**: Check logs for:
+```
+[Warm Validate] Script lookup debug: [...]
+[Warm Validate] Title search failed, trying most recent script with recency check...
+```
+
+### Screenshot Locations
+
+- Local: Screenshots saved to project root
+- Production: `/data/screenshots/` on Fly.io volume
+  ```bash
+  fly ssh console -C "ls -lt /data/screenshots/"
+  fly ssh sftp get /data/screenshots/<filename>.png
+  ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # Development Workflow
 
+## Deployment
+- This project deploys to **Fly.io**
+- Use `fly logs` (streaming) to tail logs in real-time - **prefer this over chunked fetches**
+- Use `fly logs --no-tail` only for quick snapshots
+- Use `fly status` to check app status
+- Use `fly deploy` to deploy manually
+
 ## Branch Strategy
 - Work in feature branches: `feat/<feature-name>`
 - Never commit directly to `master`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,23 @@ Reference these notes for:
 
 ## TradingView Automation Notes
 
-### Critical: /pine/ vs /chart/ Page Differences
+### CRITICAL: /pine/ vs /chart/ - Publishing REQUIRES /chart/
 
-**The "Publish script" option ONLY exists on the /chart/ page, NOT on /pine/.**
+**PUBLISHING CAN ONLY BE DONE ON /chart/ PAGE. NEVER ON /pine/.**
 
-The script name dropdown on `/pine/` page contains:
+| Feature | /pine/ Page | /chart/ Page |
+|---------|-------------|--------------|
+| Validate script | ✅ Yes | ✅ Yes |
+| Add to chart | ✅ Yes | ✅ Yes |
+| **Publish script** | ❌ NO | ✅ **YES** |
+| Has canvas element | ✅ Yes (mini preview) | ✅ Yes (full chart) |
+| Has Monaco editor | ✅ Yes (fullscreen) | ✅ Yes (in panel) |
+
+**Common Pitfall**: The `/pine/` page has a canvas element (mini chart preview), which can trick code into thinking it's on the chart page. ALWAYS check the URL contains `/chart/` before attempting to publish.
+
+### Script Name Dropdown on /pine/ (NO Publish option!)
+
+The dropdown on `/pine/` page contains:
 - Save script (Ctrl + S)
 - Make a copy…
 - Rename…
@@ -43,18 +55,20 @@ The script name dropdown on `/pine/` page contains:
 - Create new
 - Open script… (Ctrl + O)
 
-**NO Publish option exists in this menu.**
+**NO Publish option exists in this menu on /pine/.**
 
-The "Publish script" button is only available in the **Pine Editor toolbar on the /chart/ page**. To publish a script:
+### How to Publish
+
+The "Publish script" button is ONLY available in the **Pine Editor toolbar on the /chart/ page**:
 1. Navigate to `/chart/` (not `/pine/`)
-2. Open the Pine Editor panel (click Pine button in bottom toolbar)
+2. Open the Pine Editor panel
 3. The "Publish script" button appears in the Pine Editor's own toolbar
 
-### Workflow Implications
-- **Validation**: Can be done on `/pine/` page (has "Add to chart" button)
-- **Publishing**: MUST be done on `/chart/` page (has "Publish script" button in Pine Editor toolbar)
+### Workflow Summary
+- **Validation**: `/pine/` page (fast, has "Add to chart")
+- **Publishing**: MUST navigate to `/chart/` page (has "Publish script" button)
 
-This is why the combined validation+publish flow navigates between pages.
+The combined validation+publish flow MUST navigate from /pine/ to /chart/ after validation.
 
 ### Known Issue: Opening Pine Editor on /chart/
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ pine-script-wrapper/
 ```bash
 npm run dev       # Start development server
 npm run dev:log   # Dev server with logging to /tmp/pine-dev.log
+npm run skill:pine-validate  # Fly logs + Playwright MCP validation/publish run
 npm run build     # Build for production
 npm run preview   # Preview production build
 npm run test      # Run tests

--- a/fly.toml
+++ b/fly.toml
@@ -29,5 +29,5 @@ primary_region = 'iad'
   processes = ['app']
 
 [[vm]]
-  memory = '1024mb'
+  memory = '2048mb'
   cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -4,7 +4,7 @@
 #
 
 app = 'pine-script-wrapper'
-primary_region = 'sjc'
+primary_region = 'iad'
 
 [build]
 
@@ -13,6 +13,12 @@ primary_region = 'sjc'
   PORT = '3000'
   # Phase B: Use /pine/ endpoint for faster validation/publishing
   TV_USE_PINE_PAGE = 'true'
+  # Persistent screenshot storage on Fly volume
+  SCREENSHOT_DIR = '/data/screenshots'
+
+[[mounts]]
+  source = "screenshots"
+  destination = "/data/screenshots"
 
 [http_service]
   internal_port = 3000

--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ primary_region = 'sjc'
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = 'suspend'
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite dev --port 3000",
     "dev:log": "./scripts/dev.sh",
+    "skill:pine-validate": "./skills/pine-validate/scripts/run.sh",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3000",
+    "dev:log": "./scripts/dev.sh",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Dev server with logging for Claude to read
+
+LOG_FILE="/tmp/pine-dev.log"
+
+# Clear old log and Chrome locks
+> "$LOG_FILE"
+rm -f ~/.puppeteer-chrome-profile/Singleton* 2>/dev/null
+
+echo "Starting dev server..."
+echo "Log file: $LOG_FILE"
+echo ""
+
+cd "$(dirname "$0")/.." && npm run dev 2>&1 | tee "$LOG_FILE"

--- a/scripts/sync-session-to-prod.sh
+++ b/scripts/sync-session-to-prod.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+#
+# Sync TradingView session from local Redis to production Fly.io
+#
+# This script reads the service account session from local Redis
+# and uploads it to the production environment via the admin API.
+#
+# Prerequisites:
+# - Local Redis running with TradingView session saved
+# - ADMIN_API_KEY set in production (fly secrets)
+# - jq installed for JSON parsing
+#
+# Usage:
+#   ./scripts/sync-session-to-prod.sh
+#
+
+set -e
+
+# Configuration
+REDIS_KEY="service-account:session"
+PROD_URL="${PROD_URL:-https://pine-script-wrapper.fly.dev}"
+ADMIN_API_KEY="${ADMIN_API_KEY:-}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}=== Syncing TradingView Session to Production ===${NC}"
+echo ""
+
+# Check for required tools
+if ! command -v redis-cli &> /dev/null; then
+    echo -e "${RED}Error: redis-cli not found. Install Redis CLI tools.${NC}"
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo -e "${RED}Error: jq not found. Install jq for JSON parsing.${NC}"
+    exit 1
+fi
+
+if ! command -v curl &> /dev/null; then
+    echo -e "${RED}Error: curl not found.${NC}"
+    exit 1
+fi
+
+# Check for admin API key
+if [ -z "$ADMIN_API_KEY" ]; then
+    echo -e "${YELLOW}ADMIN_API_KEY not set. Reading from fly secrets...${NC}"
+    ADMIN_API_KEY=$(fly secrets list --json 2>/dev/null | jq -r '.[] | select(.Name=="ADMIN_API_KEY") | .Digest' || echo "")
+
+    if [ -z "$ADMIN_API_KEY" ] || [ "$ADMIN_API_KEY" == "null" ]; then
+        echo -e "${RED}Error: ADMIN_API_KEY not found. Set it via:${NC}"
+        echo "  export ADMIN_API_KEY=your-key"
+        echo "  or"
+        echo "  fly secrets set ADMIN_API_KEY=your-key"
+        exit 1
+    fi
+
+    # We can't read the actual value from fly secrets, prompt for it
+    echo -e "${YELLOW}Please enter your ADMIN_API_KEY:${NC}"
+    read -s ADMIN_API_KEY
+    echo ""
+fi
+
+# Read session from local Redis
+echo -e "${YELLOW}Reading session from local Redis...${NC}"
+SESSION_DATA=$(redis-cli GET "$REDIS_KEY" 2>/dev/null || echo "")
+
+if [ -z "$SESSION_DATA" ]; then
+    echo -e "${RED}Error: No session found in local Redis at key '$REDIS_KEY'${NC}"
+    echo ""
+    echo "Make sure you have a valid TradingView session saved locally."
+    echo "You can save one by logging in via the app or using the admin upload endpoint."
+    exit 1
+fi
+
+# Parse session data
+SESSION_ID=$(echo "$SESSION_DATA" | jq -r '.sessionId')
+SESSION_SIGN=$(echo "$SESSION_DATA" | jq -r '.signature')
+
+if [ "$SESSION_ID" == "null" ] || [ -z "$SESSION_ID" ]; then
+    echo -e "${RED}Error: Invalid session data - missing sessionId${NC}"
+    exit 1
+fi
+
+if [ "$SESSION_SIGN" == "null" ] || [ -z "$SESSION_SIGN" ]; then
+    echo -e "${RED}Error: Invalid session data - missing signature${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Found session in local Redis${NC}"
+echo "  Session ID: ${SESSION_ID:0:10}..."
+echo "  Signature: ${SESSION_SIGN:0:10}..."
+echo ""
+
+# Upload to production
+echo -e "${YELLOW}Uploading session to production ($PROD_URL)...${NC}"
+
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$PROD_URL/api/admin/tv-session/upload" \
+    -H "Content-Type: application/json" \
+    -H "x-admin-key: $ADMIN_API_KEY" \
+    -d "{\"sessionId\": \"$SESSION_ID\", \"sessionIdSign\": \"$SESSION_SIGN\", \"skipVerify\": true}")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" == "200" ]; then
+    echo -e "${GREEN}Success! Session uploaded to production.${NC}"
+    echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
+else
+    echo -e "${RED}Error: Upload failed (HTTP $HTTP_CODE)${NC}"
+    echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}=== Done ===${NC}"
+echo ""
+echo "The warm local browser in production will now use these credentials."
+echo "Monitor with: fly logs"

--- a/server/plugins/pre-warm.ts
+++ b/server/plugins/pre-warm.ts
@@ -1,0 +1,34 @@
+/**
+ * Pre-warm Plugin
+ *
+ * Starts Chrome initialization immediately when the server boots.
+ * This eliminates cold start latency (~60s) for the first validation request.
+ *
+ * Runs automatically via Nitro's plugin system.
+ */
+
+import { isWarmLocalBrowserEnabled, startPreWarm } from '../../src/server/warm-session'
+import { getServiceAccountCredentials } from '../../src/server/service-validation'
+
+export default async function preWarmPlugin() {
+  console.log('[Plugin:pre-warm] Initializing...')
+
+  if (!isWarmLocalBrowserEnabled()) {
+    console.log('[Plugin:pre-warm] USE_WARM_LOCAL_BROWSER is not enabled, skipping pre-warm')
+    return
+  }
+
+  console.log('[Plugin:pre-warm] USE_WARM_LOCAL_BROWSER=true, starting pre-warm...')
+
+  try {
+    const credentials = await getServiceAccountCredentials()
+    if (credentials) {
+      startPreWarm(credentials)
+      console.log('[Plugin:pre-warm] Pre-warm initiated (running in background)')
+    } else {
+      console.warn('[Plugin:pre-warm] No service account credentials available, skipping pre-warm')
+    }
+  } catch (error) {
+    console.error('[Plugin:pre-warm] Failed to start pre-warm:', error)
+  }
+}

--- a/skills/pine-validate/SKILL.md
+++ b/skills/pine-validate/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: pine-validate
+description: Validate and publish Pine Script using browser automation with Fly log correlation for debugging TradingView automation issues.
+metadata:
+  short-description: Validate and debug Pine publish flow
+---
+
+# Pine Validate
+
+Validate and publish a Pine Script indicator through the Pine Script Publisher web app using Playwright MCP and correlate browser actions with live Fly logs.
+
+## Use This Skill
+
+Use this skill when you need one or more of:
+- End-to-end validate+publish smoke test.
+- Repro of TradingView automation regressions.
+- Fly log correlation with a concrete browser run.
+
+## Required Prerequisites
+
+- `codex` CLI installed and authenticated.
+- Playwright MCP installed and registered as `playwright`:
+  - `codex mcp list`
+  - Must show `playwright` and `enabled`.
+- Fly CLI authenticated with access to app logs.
+
+## Default Behavior
+
+- Use the prefilled script in the web app unless the user explicitly provides script code or a script file.
+- Always collect Fly logs while running browser automation.
+- Always capture initial and final snapshots.
+
+## Fast Path
+
+Run the bundled script:
+
+```bash
+skills/pine-validate/scripts/run.sh
+```
+
+Optional arguments:
+
+```bash
+skills/pine-validate/scripts/run.sh \
+  --title "My Indicator" \
+  --description "Validation run from pine-validate skill" \
+  --script-file src/test-scripts/complex-valid.pine \
+  --fly-app pine-script-wrapper \
+  --site-url https://pine-script-wrapper.fly.dev
+```
+
+## Workflow
+
+1. Start Fly logs in background (`fly logs -a <app>`).
+2. Run `codex exec` with a Playwright MCP prompt that:
+   - navigates to the app
+   - keeps prefilled script unless explicit script input exists
+   - clicks Validate & Publish
+   - fills title/description if needed
+   - waits for final validation/publish result
+   - reports outcome and any failure point
+3. Stop logs and extract correlation lines:
+   - `ValidationLoop`
+   - `Warm Validate`
+   - `TV Publish`
+   - `URL_CAPTURE_FAILED_AFTER_PUBLISH`
+4. Return:
+   - MCP run output
+   - raw Fly logs
+   - correlation summary
+
+## Files In This Skill
+
+- `scripts/run.sh`:
+  - end-to-end runner for Fly logs + Playwright MCP automation + correlation output.
+- `references/prompt-template.md`:
+  - shared automation prompt template used by `run.sh`.
+
+## Critical TradingView Rules
+
+- Publishing must complete from `/chart/` context, not `/pine/`.
+- Do not press `Escape` during Pine editor interactions.
+- If publish URL is missing, inspect logs for indexing delay and `URL_CAPTURE_FAILED_AFTER_PUBLISH`.

--- a/skills/pine-validate/references/prompt-template.md
+++ b/skills/pine-validate/references/prompt-template.md
@@ -1,0 +1,23 @@
+You are executing the pine-validate workflow for Pine Script Publisher.
+
+Constraints:
+- Use Playwright MCP for browser actions.
+- Navigate to {{SITE_URL}}.
+- Take an initial snapshot, then a final snapshot.
+- Unless explicit script code is provided below, keep the prefilled script in the editor.
+- Click "Validate & Publish".
+- Fill title and description if fields are shown.
+- Wait for final result and report:
+  - validation success/failure
+  - publish success/failure
+  - published indicator URL if available
+  - exact failure step if not successful
+
+Indicator metadata:
+- title: {{TITLE}}
+- description: {{DESCRIPTION}}
+
+Script override (optional, may be empty):
+{{SCRIPT_BLOCK}}
+
+Return a concise run report with timestamps and key page states.

--- a/skills/pine-validate/scripts/run.sh
+++ b/skills/pine-validate/scripts/run.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Run Pine validate skill end-to-end (Fly logs + Playwright MCP via codex exec).
+
+Usage:
+  skills/pine-validate/scripts/run.sh [options]
+
+Options:
+  --title <text>         Indicator title (default: Pine Validate Smoke Test)
+  --description <text>   Indicator description (default: Validation run via pine-validate skill)
+  --script-file <path>   Optional Pine script file to paste instead of prefilled editor text
+  --fly-app <name>       Fly app name (default: pine-script-wrapper)
+  --site-url <url>       App URL (default: https://pine-script-wrapper.fly.dev)
+  --log-seconds <n>      Max Fly log streaming duration in seconds (default: 180)
+  --exec-seconds <n>     Max codex exec duration in seconds (default: 240)
+  --out-dir <path>       Output directory (default: logs/pine-validate-<timestamp>)
+  --prepare-only         Generate prompt/output files but do not execute run
+  -h, --help             Show help
+USAGE
+}
+
+TITLE='Pine Validate Smoke Test'
+DESCRIPTION='Validation run via pine-validate skill'
+SCRIPT_FILE=''
+FLY_APP='pine-script-wrapper'
+SITE_URL='https://pine-script-wrapper.fly.dev'
+LOG_SECONDS='180'
+EXEC_SECONDS='240'
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT_DIR="logs/pine-validate-${STAMP}"
+PREPARE_ONLY='false'
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)
+      TITLE="${2:-}"
+      shift 2
+      ;;
+    --description)
+      DESCRIPTION="${2:-}"
+      shift 2
+      ;;
+    --script-file)
+      SCRIPT_FILE="${2:-}"
+      shift 2
+      ;;
+    --fly-app)
+      FLY_APP="${2:-}"
+      shift 2
+      ;;
+    --site-url)
+      SITE_URL="${2:-}"
+      shift 2
+      ;;
+    --log-seconds)
+      LOG_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --exec-seconds)
+      EXEC_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --prepare-only)
+      PREPARE_ONLY='true'
+      shift 1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need_cmd codex
+need_cmd fly
+need_cmd timeout
+need_cmd rg
+
+if ! codex mcp get playwright >/dev/null 2>&1; then
+  echo "Playwright MCP server is not configured. Run: codex mcp add playwright -- npx -y @playwright/mcp@latest" >&2
+  exit 1
+fi
+
+if [[ -n "$SCRIPT_FILE" && ! -f "$SCRIPT_FILE" ]]; then
+  echo "Script file not found: $SCRIPT_FILE" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+LOG_FILE="$OUT_DIR/fly.log"
+CORRELATION_FILE="$OUT_DIR/correlation.log"
+PROMPT_FILE="$OUT_DIR/prompt.md"
+REPORT_FILE="$OUT_DIR/codex-report.txt"
+
+SCRIPT_BLOCK='(none; use prefilled script from editor)'
+if [[ -n "$SCRIPT_FILE" ]]; then
+  SCRIPT_CONTENT="$(cat "$SCRIPT_FILE")"
+  SCRIPT_BLOCK=$(cat <<BLOCK
+\`\`\`pine
+$SCRIPT_CONTENT
+\`\`\`
+BLOCK
+)
+fi
+
+TEMPLATE="skills/pine-validate/references/prompt-template.md"
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "Missing prompt template: $TEMPLATE" >&2
+  exit 1
+fi
+
+escape_sed() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+TMP_FILE="$OUT_DIR/prompt.tmp.md"
+cp "$TEMPLATE" "$TMP_FILE"
+sed -i \
+  -e "s|{{SITE_URL}}|$(escape_sed "$SITE_URL")|g" \
+  -e "s|{{TITLE}}|$(escape_sed "$TITLE")|g" \
+  -e "s|{{DESCRIPTION}}|$(escape_sed "$DESCRIPTION")|g" \
+  "$TMP_FILE"
+
+SCRIPT_BLOCK_FILE="$OUT_DIR/script-block.md"
+printf '%s\n' "$SCRIPT_BLOCK" > "$SCRIPT_BLOCK_FILE"
+awk -v block_file="$SCRIPT_BLOCK_FILE" '
+  {
+    if ($0 ~ /{{SCRIPT_BLOCK}}/) {
+      while ((getline line < block_file) > 0) print line
+      close(block_file)
+    } else {
+      print $0
+    }
+  }
+' "$TMP_FILE" > "$PROMPT_FILE"
+rm -f "$TMP_FILE" "$SCRIPT_BLOCK_FILE"
+
+cleanup() {
+  if [[ -n "${LOG_PID:-}" ]]; then
+    kill "$LOG_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$PREPARE_ONLY" == 'true' ]]; then
+  cat <<DONE
+[pine-validate] Prepared only.
+- Prompt file: $PROMPT_FILE
+- Title: $TITLE
+- Description: $DESCRIPTION
+- Script file: ${SCRIPT_FILE:-'(prefilled editor script)'}
+DONE
+  exit 0
+fi
+
+echo "[pine-validate] Output directory: $OUT_DIR"
+echo "[pine-validate] Streaming Fly logs for up to ${LOG_SECONDS}s from app: $FLY_APP"
+(timeout "${LOG_SECONDS}s" fly logs -a "$FLY_APP" 2>&1 | tee "$LOG_FILE") &
+LOG_PID=$!
+
+sleep 2
+
+echo "[pine-validate] Running browser automation via codex exec + Playwright MCP"
+if ! timeout "${EXEC_SECONDS}s" codex exec --dangerously-bypass-approvals-and-sandbox "$(cat "$PROMPT_FILE")" | tee "$REPORT_FILE"; then
+  echo "[pine-validate] codex exec run failed" >&2
+fi
+
+wait "$LOG_PID" || true
+
+echo "[pine-validate] Extracting correlation lines"
+rg -n "ValidationLoop|Warm Validate|TV Publish|URL_CAPTURE_FAILED_AFTER_PUBLISH|Script published|publish" "$LOG_FILE" > "$CORRELATION_FILE" || true
+
+cat <<DONE
+[pine-validate] Completed.
+- Browser report: $REPORT_FILE
+- Fly logs: $LOG_FILE
+- Correlation summary: $CORRELATION_FILE
+DONE

--- a/src/routes/validate.tsx
+++ b/src/routes/validate.tsx
@@ -78,7 +78,8 @@ function ValidatePage() {
   })
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
-  const [visibility, setVisibility] = useState<'public' | 'private'>('public')
+  // Visibility is always public when using service account
+  const visibility = 'public' as const
   const [isCreatingCheckout, setIsCreatingCheckout] = useState(false)
   const [productDetails, setProductDetails] = useState<ProductDetails | null>(null)
 
@@ -257,34 +258,6 @@ function ValidatePage() {
               placeholder="Describe what your indicator does..."
               rows={3}
             />
-          </div>
-
-          <div className="form-group">
-            <label>Visibility</label>
-            <div className="visibility-options">
-              <label className="radio-label">
-                <input
-                  type="radio"
-                  name="visibility"
-                  value="public"
-                  checked={visibility === 'public'}
-                  onChange={() => setVisibility('public')}
-                />
-                <span>Public</span>
-                <small>Anyone can view and use your indicator</small>
-              </label>
-              <label className="radio-label">
-                <input
-                  type="radio"
-                  name="visibility"
-                  value="private"
-                  checked={visibility === 'private'}
-                  onChange={() => setVisibility('private')}
-                />
-                <span>Private</span>
-                <small>Only you can see and use this indicator</small>
-              </label>
-            </div>
           </div>
 
           <div className="price-info">

--- a/src/routes/validate.tsx
+++ b/src/routes/validate.tsx
@@ -107,10 +107,14 @@ function ValidatePage() {
     fetchProductDetails().then(setProductDetails).catch(console.error)
   }, [])
 
-  // Validate AND publish in one step (after user fills in title)
+  // Validate AND publish in one step (after user fills in title and description)
   const runValidationAndPublish = async () => {
     if (!title.trim()) {
       alert('Please enter a title for your indicator')
+      return
+    }
+    if (!description.trim()) {
+      alert('Please enter a description for your indicator (required by TradingView)')
       return
     }
 
@@ -249,7 +253,7 @@ function ValidatePage() {
           </div>
 
           <div className="form-group">
-            <label htmlFor="description">Description (optional)</label>
+            <label htmlFor="description">Description *</label>
             <textarea
               id="description"
               className="input"
@@ -257,6 +261,7 @@ function ValidatePage() {
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Describe what your indicator does..."
               rows={3}
+              required
             />
           </div>
 
@@ -268,9 +273,9 @@ function ValidatePage() {
           <button
             className="btn btn-primary btn-large"
             onClick={runValidationAndPublish}
-            disabled={!title.trim()}
+            disabled={!title.trim() || !description.trim()}
           >
-            {title.trim() ? 'Validate & Publish' : 'Enter title to continue'}
+            {!title.trim() ? 'Enter title to continue' : !description.trim() ? 'Enter description to continue' : 'Validate & Publish'}
           </button>
         </div>
       )}

--- a/src/server/browserless.ts
+++ b/src/server/browserless.ts
@@ -11,6 +11,16 @@ const CHROME_USER_DATA_DIR = process.env.CHROME_USER_DATA_DIR // Use existing Ch
 const PUPPETEER_EXECUTABLE_PATH = process.env.PUPPETEER_EXECUTABLE_PATH // Set by Dockerfile for production
 const BROWSERLESS_STEALTH = process.env.BROWSERLESS_STEALTH !== 'false' // Default: enabled
 const BROWSERLESS_PROXY = process.env.BROWSERLESS_PROXY // 'residential' or 'datacenter'
+const BROWSERLESS_REPLAY = process.env.BROWSERLESS_REPLAY === 'true' // Session replay for debugging
+
+// Log browser configuration at startup
+console.log('[Browser Config]', {
+  USE_LOCAL_BROWSER,
+  PUPPETEER_EXECUTABLE_PATH: PUPPETEER_EXECUTABLE_PATH || '(not set)',
+  BROWSERLESS_API_KEY: BROWSERLESS_API_KEY ? '(set)' : '(not set)',
+  BROWSERLESS_STEALTH,
+  BROWSERLESS_PROXY: BROWSERLESS_PROXY || '(not set)',
+})
 
 /**
  * Auto-detect Chrome user data directory based on OS
@@ -92,6 +102,9 @@ function buildBrowserlessEndpoint(): string {
   if (BROWSERLESS_PROXY) {
     params.set('proxy', BROWSERLESS_PROXY)
   }
+  if (BROWSERLESS_REPLAY) {
+    params.set('record', 'true')
+  }
 
   return `${endpoint}?${params.toString()}`
 }
@@ -99,6 +112,12 @@ function buildBrowserlessEndpoint(): string {
 export interface BrowserlessSession {
   browser: Browser
   page: Page
+}
+
+export interface ReconnectableBrowserSession extends BrowserlessSession {
+  cdpSession?: CDPSession
+  reconnectEndpoint?: string
+  isBrowserless: boolean
 }
 
 export interface BrowserSessionOptions {
@@ -113,9 +132,18 @@ export interface BrowserSessionOptions {
  * - Falls back to Browserless.io if neither is available
  * @param options.forceVisible - Force visible browser for CAPTCHA solving
  */
-export async function createBrowserSession(options?: BrowserSessionOptions): Promise<BrowserlessSession> {
+export async function createBrowserSession(options?: BrowserSessionOptions): Promise<ReconnectableBrowserSession> {
   const forceVisible = options?.forceVisible ?? false
   let browser: Browser
+
+  console.log('[Browser] Creating session...', {
+    forceVisible,
+    USE_LOCAL_BROWSER,
+    PUPPETEER_EXECUTABLE_PATH: PUPPETEER_EXECUTABLE_PATH || '(not set)',
+    BROWSERLESS_API_KEY: BROWSERLESS_API_KEY ? '(set)' : '(not set)',
+  })
+
+  let isBrowserless = false
 
   if (USE_LOCAL_BROWSER || forceVisible) {
     // Launch local Chrome
@@ -191,6 +219,7 @@ export async function createBrowserSession(options?: BrowserSessionOptions): Pro
     browser = await puppeteer.connect({
       browserWSEndpoint: wsEndpoint,
     })
+    isBrowserless = true
   } else {
     throw new Error(
       'No browser available. Set one of: USE_LOCAL_BROWSER=true, PUPPETEER_EXECUTABLE_PATH, or BROWSERLESS_API_KEY'
@@ -213,7 +242,7 @@ export async function createBrowserSession(options?: BrowserSessionOptions): Pro
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
   )
 
-  return { browser, page }
+  return { browser, page, isBrowserless }
 }
 
 /**
@@ -221,6 +250,126 @@ export async function createBrowserSession(options?: BrowserSessionOptions): Pro
  */
 export async function closeBrowserSession(session: BrowserlessSession): Promise<void> {
   await session.browser.close()
+}
+
+// ============ Browserless Reconnect Support ============
+
+/**
+ * Enable reconnect on a Browserless session
+ * Free plan: 10s max reconnect timeout
+ * Must call this before any operation that might exceed session timeout
+ */
+export async function enableBrowserlessReconnect(
+  session: ReconnectableBrowserSession,
+  timeoutMs: number = 10000  // Free plan max
+): Promise<string | null> {
+  if (!session.isBrowserless) {
+    return null // Not applicable for local browser
+  }
+
+  try {
+    const cdpSession = await session.page.createCDPSession()
+    session.cdpSession = cdpSession
+
+    const result = await cdpSession.send('Browserless.reconnect' as any, {
+      timeout: timeoutMs,
+    }) as { browserWSEndpoint?: string; error?: string }
+
+    if (result.error) {
+      console.error('[Browserless] Reconnect setup failed:', result.error)
+      return null
+    }
+
+    session.reconnectEndpoint = result.browserWSEndpoint
+    console.log('[Browserless] Reconnect enabled, endpoint:', result.browserWSEndpoint)
+    return result.browserWSEndpoint || null
+  } catch (error) {
+    console.error('[Browserless] Failed to enable reconnect:', error)
+    return null
+  }
+}
+
+/**
+ * Reconnect to a Browserless session using saved endpoint
+ */
+export async function reconnectToBrowserless(
+  reconnectEndpoint: string
+): Promise<ReconnectableBrowserSession | null> {
+  try {
+    const params = new URLSearchParams()
+    params.set('token', BROWSERLESS_API_KEY!)
+
+    const wsEndpoint = `${reconnectEndpoint}?${params.toString()}`
+    console.log('[Browserless] Reconnecting to session...')
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: wsEndpoint,
+    })
+
+    const pages = await browser.pages()
+    const page = pages[0] || await browser.newPage()
+
+    console.log('[Browserless] Reconnected successfully')
+    return {
+      browser,
+      page,
+      isBrowserless: true,
+      reconnectEndpoint,
+    }
+  } catch (error) {
+    console.error('[Browserless] Reconnect failed:', error)
+    return null
+  }
+}
+
+/**
+ * Execute a long operation with automatic reconnect handling for Browserless
+ * Splits operation into chunks, reconnecting between them if needed
+ */
+export async function withBrowserlessReconnect<T>(
+  session: ReconnectableBrowserSession,
+  operation: (session: ReconnectableBrowserSession) => Promise<T>,
+  options?: {
+    maxReconnects?: number
+    reconnectTimeoutMs?: number
+  }
+): Promise<T> {
+  const { maxReconnects = 3, reconnectTimeoutMs = 10000 } = options || {}
+
+  if (!session.isBrowserless) {
+    // Local browser - just run the operation
+    return operation(session)
+  }
+
+  // Enable reconnect before starting
+  await enableBrowserlessReconnect(session, reconnectTimeoutMs)
+
+  try {
+    return await operation(session)
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+
+    // Check if this is a session timeout error
+    if (errorMsg.includes('Target closed') ||
+        errorMsg.includes('Session closed') ||
+        errorMsg.includes('Detached Frame')) {
+
+      if (session.reconnectEndpoint && maxReconnects > 0) {
+        console.log('[Browserless] Session timeout detected, attempting reconnect...')
+
+        const newSession = await reconnectToBrowserless(session.reconnectEndpoint)
+        if (newSession) {
+          // Retry with reconnected session
+          return withBrowserlessReconnect(newSession, operation, {
+            maxReconnects: maxReconnects - 1,
+            reconnectTimeoutMs,
+          })
+        }
+      }
+    }
+
+    throw error
+  }
 }
 
 /**

--- a/src/server/tradingview.ts
+++ b/src/server/tradingview.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import {
   createBrowserSession,
   closeBrowserSession,
@@ -9,6 +10,32 @@ import {
 
 // Helper function for delays
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// ============ Browserless Concurrency Lock ============
+// Serializes access to Browserless to prevent 429 rate limit errors.
+// Browserless plan limits concurrent sessions to 1.
+let browserlessLock: Promise<void> | null = null
+let browserlessLockResolve: (() => void) | null = null
+
+async function acquireBrowserlessLock(requestId: string): Promise<void> {
+  while (browserlessLock) {
+    console.log(`[Browserless:${requestId}] Session in use, waiting...`)
+    await browserlessLock
+  }
+  browserlessLock = new Promise(resolve => {
+    browserlessLockResolve = resolve
+  })
+  console.log(`[Browserless:${requestId}] Lock acquired`)
+}
+
+function releaseBrowserlessLock(requestId: string): void {
+  if (browserlessLockResolve) {
+    console.log(`[Browserless:${requestId}] Lock released`)
+    browserlessLockResolve()
+    browserlessLockResolve = null
+    browserlessLock = null
+  }
+}
 
 // ============ Admin Session Cache (In-memory only, for server-level credentials) ============
 // This cache is ONLY for admin auto-login with TV_USERNAME/TV_PASSWORD environment variables.
@@ -71,7 +98,8 @@ const TV_URLS = {
 } as const
 
 // TradingView DOM selectors - maintain separately for easy updates when TV changes UI
-const TV_SELECTORS = {
+// Exported for use by warm-session.ts
+export const TV_SELECTORS = {
   // Pine Editor
   pineEditor: {
     container: '[data-name="pine-editor"]',
@@ -979,11 +1007,10 @@ export async function validatePineScript(
         }
       }
 
-      // Wait for Pine Editor to appear - give it more time
+      // Wait for Pine Editor to appear - try all selectors in parallel
       console.log('[TV] Waiting for Pine Editor to load...')
-      await delay(5000) // Give it 5 seconds to start loading
 
-      // Try multiple selectors for Pine Editor container
+      // Try multiple selectors for Pine Editor container - in parallel
       const pineEditorSelectors = [
         '[data-name="pine-editor"]',
         '.pine-editor-container',
@@ -992,14 +1019,22 @@ export async function validatePineScript(
         '.monaco-editor', // The code editor itself
       ]
 
+      // Race all selectors - first one to match wins
       let editorOpened = false
-      for (const selector of pineEditorSelectors) {
-        const found = await waitForElement(page, selector, 3000)
-        if (found) {
-          console.log(`[TV] Pine Editor found with selector: ${selector}`)
-          editorOpened = true
-          break
-        }
+      const selectorPromises = pineEditorSelectors.map(async (selector) => {
+        const found = await waitForElement(page, selector, 15000)
+        if (found) return selector
+        return null
+      })
+
+      const winningSelector = await Promise.race([
+        Promise.any(selectorPromises.map(p => p.then(s => s ? s : Promise.reject()))).catch(() => null),
+        delay(15000).then(() => null), // Overall timeout
+      ])
+
+      if (winningSelector) {
+        console.log(`[TV] Pine Editor found with selector: ${winningSelector}`)
+        editorOpened = true
       }
 
       if (!editorOpened) {
@@ -2283,5 +2318,1545 @@ async function publishPineScriptV2(
     if (session) {
       await closeBrowserSession(session)
     }
+  }
+}
+
+/**
+ * Combined result for validate and publish
+ */
+export interface ValidateAndPublishResult {
+  validation: ValidationResult
+  publish?: PublishResult
+  /** If true, failure was due to infrastructure (session disconnect, etc.) - don't retry with AI fix */
+  infrastructureError?: boolean
+}
+
+/**
+ * Validate and optionally publish a Pine Script using an existing warm session
+ * This is the fastest path - browser already has TradingView loaded with Pine Editor open
+ * Used when USE_WARM_LOCAL_BROWSER=true
+ *
+ * @param page - Pre-loaded page with Pine Editor already open
+ * @param script - Pine Script code to validate
+ * @param publishOptions - Optional publish settings
+ * @returns Validation and optionally publish result
+ */
+export async function validateAndPublishWithWarmSession(
+  page: import('puppeteer-core').Page,
+  script: string,
+  publishOptions?: {
+    title: string
+    description: string
+    visibility?: 'public' | 'private'
+  }
+): Promise<ValidateAndPublishResult> {
+  const startTime = Date.now()
+  console.log('[Warm Validate] Starting validation with warm session...')
+
+  // Track response handler at function level so we can clean up in catch block
+  let registeredResponseHandler: ((response: import('puppeteer-core').HTTPResponse) => void) | null = null
+
+  try {
+    // Reset editor state (clear previous content)
+    console.log('[Warm Validate] Resetting editor state...')
+    await page.keyboard.press('Escape')
+    await delay(100)
+    await page.keyboard.press('Escape')
+    await delay(100)
+
+    // Check if Monaco editor is accessible (might have navigated away after last publish)
+    let editorExists = await page.$('.monaco-editor')
+
+    if (!editorExists) {
+      console.log('[Warm Validate] Monaco editor not found, navigating back to chart...')
+      const currentUrl = page.url()
+      console.log(`[Warm Validate] Current URL: ${currentUrl}`)
+
+      // Navigate back to chart page
+      await page.goto('https://www.tradingview.com/chart/', {
+        waitUntil: 'networkidle2',
+        timeout: 30000,
+      })
+      await delay(2000)
+
+      // Reopen Pine Editor
+      const editorButtonSelectors = [
+        TV_SELECTORS.chart.pineEditorButton,
+        'button[title="Pine"]',
+        'button[aria-label="Pine"]',
+      ]
+
+      for (const selector of editorButtonSelectors) {
+        try {
+          const button = await page.$(selector)
+          if (button) {
+            await button.click()
+            console.log(`[Warm Validate] Clicked Pine Editor button: ${selector}`)
+            break
+          }
+        } catch {
+          // Try next
+        }
+      }
+
+      // Wait for editor to load
+      await page.waitForSelector('.monaco-editor', { timeout: 10000 })
+      await delay(500)
+      console.log('[Warm Validate] Pine Editor reopened')
+      editorExists = await page.$('.monaco-editor')
+    }
+
+    if (!editorExists) {
+      throw new Error('Monaco editor not found after navigation')
+    }
+
+    // Remove existing indicators from the chart (TradingView free tier limits to 2)
+    console.log('[Warm Validate] Removing existing indicators from chart...')
+    const removedCount = await page.evaluate(() => {
+      let removed = 0
+      // Find all indicator legends/headers on the chart
+      const indicatorHeaders = document.querySelectorAll('[data-name="legend-source-item"], [class*="legend-"] [class*="title"], .chart-controls-bar [data-name]')
+
+      for (const header of indicatorHeaders) {
+        // Look for close/remove button within or near the indicator
+        const closeBtn = header.querySelector('[data-name="legend-delete-action"], [class*="close"], [class*="remove"], [aria-label*="Remove"]') as HTMLElement
+        if (closeBtn) {
+          closeBtn.click()
+          removed++
+        }
+      }
+
+      // Also try clicking any visible "Remove" buttons in indicator panels
+      const removeButtons = document.querySelectorAll('[data-name="legend-delete-action"], button[aria-label*="Remove" i]')
+      for (const btn of removeButtons) {
+        try {
+          (btn as HTMLElement).click()
+          removed++
+        } catch {
+          // Ignore
+        }
+      }
+
+      return removed
+    })
+
+    if (removedCount > 0) {
+      console.log(`[Warm Validate] Removed ${removedCount} existing indicators`)
+      await delay(500)
+    }
+
+    // Click on Monaco editor to focus
+    await page.click('.monaco-editor')
+    await delay(100)
+
+    // Select all and delete
+    await page.keyboard.down('Control')
+    await page.keyboard.press('a')
+    await page.keyboard.up('Control')
+    await delay(50)
+    await page.keyboard.press('Delete')
+    await delay(100)
+
+    // Insert script via clipboard paste
+    console.log('[Warm Validate] Inserting script...')
+    await page.evaluate((text) => navigator.clipboard.writeText(text), script)
+    await page.keyboard.down('Control')
+    await page.keyboard.press('v')
+    await page.keyboard.up('Control')
+    console.log('[Warm Validate] Script inserted')
+
+    // Wait for compilation
+    await delay(2000)
+
+    // Click "Add to chart" to trigger validation
+    console.log('[Warm Validate] Clicking "Add to chart"...')
+    const addToChartClicked = await page.evaluate(() => {
+      const selectors = [
+        '[data-name="add-script-to-chart"]',
+        '[aria-label*="Add to chart" i]',
+        '[title*="Add to chart" i]',
+      ]
+
+      for (const selector of selectors) {
+        try {
+          const btn = document.querySelector(selector) as HTMLElement
+          if (btn) {
+            btn.click()
+            return { clicked: true, selector }
+          }
+        } catch {
+          // Try next
+        }
+      }
+
+      // Fallback: search by text
+      const buttons = Array.from(document.querySelectorAll('button, [role="button"]'))
+      const btn = buttons.find(b => {
+        const text = b.textContent?.toLowerCase() || ''
+        return text.includes('add to chart')
+      })
+      if (btn) {
+        (btn as HTMLElement).click()
+        return { clicked: true, selector: 'text search' }
+      }
+
+      return { clicked: false, selector: null }
+    })
+
+    if (addToChartClicked.clicked) {
+      console.log(`[Warm Validate] Clicked "Add to chart": ${addToChartClicked.selector}`)
+    }
+
+    // Wait for validation to complete
+    await delay(2500)
+
+    // Extract errors from console panel
+    const errors = await page.evaluate((selectors) => {
+      const consolePanel = document.querySelector(selectors.consolePanel)
+      if (!consolePanel) return []
+
+      const errorLines = consolePanel.querySelectorAll(selectors.errorLine)
+      const warningLines = consolePanel.querySelectorAll(selectors.warningLine)
+
+      const parseConsoleLine = (element: Element, type: 'error' | 'warning') => {
+        const text = element.textContent || ''
+        const lineMatch = text.match(/line (\d+)/i)
+        return {
+          line: lineMatch ? parseInt(lineMatch[1], 10) : 0,
+          message: text.trim(),
+          type,
+        }
+      }
+
+      return [
+        ...Array.from(errorLines).map((el) => parseConsoleLine(el, 'error')),
+        ...Array.from(warningLines).map((el) => parseConsoleLine(el, 'warning')),
+      ]
+    }, TV_SELECTORS.pineEditor)
+
+    // Get raw console output
+    const rawOutput = await page.evaluate((selector) => {
+      const panel = document.querySelector(selector)
+      return panel?.textContent || ''
+    }, TV_SELECTORS.pineEditor.consolePanel)
+
+    const validationResult: ValidationResult = {
+      isValid: errors.filter((e) => e.type === 'error').length === 0,
+      errors,
+      rawOutput,
+    }
+
+    const validationTime = Date.now() - startTime
+    console.log(`[Warm Validate] Validation complete in ${validationTime}ms: isValid=${validationResult.isValid}`)
+
+    // If validation failed or no publish options, return just validation result
+    if (!validationResult.isValid || !publishOptions) {
+      return { validation: validationResult }
+    }
+
+    // === PUBLISH PHASE ===
+    console.log('[Warm Validate] Validation passed, proceeding to publish...')
+    const { title, description, visibility = 'public' } = publishOptions
+
+    // Click publish button
+    const publishButtonSelectors = [
+      '[data-name="publish-script-button"]',
+      '[data-name="save-publish-button"]',
+      '[aria-label*="Publish" i]',
+      '[title*="Publish" i]',
+    ]
+
+    let publishClicked = false
+    for (const selector of publishButtonSelectors) {
+      try {
+        const btn = await page.$(selector)
+        if (btn) {
+          await btn.click()
+          publishClicked = true
+          console.log(`[Warm Validate] Clicked publish button: ${selector}`)
+          break
+        }
+      } catch {
+        // Try next
+      }
+    }
+
+    if (!publishClicked) {
+      publishClicked = await page.evaluate(() => {
+        const buttons = Array.from(document.querySelectorAll('button, [role="button"]'))
+        const publishBtn = buttons.find(btn => {
+          const text = btn.textContent?.toLowerCase() || ''
+          const ariaLabel = btn.getAttribute('aria-label')?.toLowerCase() || ''
+          return text.includes('publish') || ariaLabel.includes('publish')
+        })
+        if (publishBtn) {
+          (publishBtn as HTMLElement).click()
+          return true
+        }
+        return false
+      })
+    }
+
+    if (!publishClicked) {
+      console.log('[Warm Validate] Publish button not found')
+      return {
+        validation: validationResult,
+        publish: { success: false, error: 'Publish button not found' },
+      }
+    }
+
+    // Wait for publish dialog
+    await delay(2000)
+
+    // Fill publish form
+    console.log('[Warm Validate] Filling publish form...')
+
+    // Try to find and fill title field
+    const titleSelectors = [
+      'input[name="title"]',
+      'input[placeholder*="title" i]',
+      'input[data-name="title"]',
+    ]
+
+    for (const selector of titleSelectors) {
+      try {
+        const input = await page.$(selector)
+        if (input) {
+          await input.click({ clickCount: 3 }) // Select all
+          await input.type(title)
+          console.log(`[Warm Validate] Filled title: ${selector}`)
+          break
+        }
+      } catch {
+        // Try next
+      }
+    }
+
+    // Try to find and fill description field
+    const descSelectors = [
+      'textarea[name="description"]',
+      'textarea[placeholder*="description" i]',
+      'textarea[data-name="description"]',
+    ]
+
+    for (const selector of descSelectors) {
+      try {
+        const textarea = await page.$(selector)
+        if (textarea) {
+          await textarea.click({ clickCount: 3 })
+          await textarea.type(description)
+          console.log(`[Warm Validate] Filled description: ${selector}`)
+          break
+        }
+      } catch {
+        // Try next
+      }
+    }
+
+    // Set visibility if private
+    if (visibility === 'private') {
+      try {
+        const privateOption = await page.$('input[value="private"], input[name*="private" i], label:has-text("Private") input')
+        if (privateOption) {
+          await privateOption.click()
+          console.log('[Warm Validate] Set visibility to private')
+        }
+      } catch {
+        console.log('[Warm Validate] Could not find private visibility option')
+      }
+    }
+
+    await delay(500)
+
+    // Set up network request interception to capture script ID from API response
+    let capturedScriptId: string | null = null
+    let loggedUrls = new Set<string>()
+
+    const responseHandler = async (response: import('puppeteer-core').HTTPResponse) => {
+      try {
+        const url = response.url()
+        const status = response.status()
+
+        // Skip non-successful responses and static assets
+        if (status < 200 || status >= 300) return
+        if (url.includes('.js') || url.includes('.css') || url.includes('.png') || url.includes('.svg') ||
+            url.includes('.woff') || url.includes('.ico') || url.includes('.jpg') || url.includes('.gif')) return
+
+        // Log ALL tradingview.com API-like URLs (not static assets) during debug
+        if (url.includes('tradingview.com') && !loggedUrls.has(url)) {
+          const urlPath = url.split('?')[0]
+          // Only log API-like paths (not static)
+          if (!urlPath.includes('/bundles/') && !urlPath.includes('/static/')) {
+            loggedUrls.add(url)
+            console.log(`[Warm Validate] Network: ${urlPath.slice(-80)}`)
+          }
+        }
+
+        // TradingView uses various endpoints for publishing - be more inclusive
+        const isRelevantUrl = url.includes('/pine_perm/') ||
+                              url.includes('/publish') ||
+                              url.includes('/script') ||
+                              url.includes('/save') ||
+                              url.includes('/create') ||
+                              url.includes('/api/')
+
+        if (isRelevantUrl) {
+          const text = await response.text().catch(() => '')
+
+          // Log the endpoint for debugging (abbreviated)
+          if (text.length > 0 && text.length < 10000) {
+            const urlPath = url.split('?')[0].slice(-60)
+            console.log(`[Warm Validate] API response from ${urlPath}: ${text.slice(0, 300)}...`)
+          }
+
+          // Look for script ID patterns in the response (various TradingView formats)
+          const idMatch = text.match(/"id"\s*:\s*"([a-zA-Z0-9]+)"/) ||
+                          text.match(/"scriptId"\s*:\s*"([a-zA-Z0-9]+)"/) ||
+                          text.match(/"script_id"\s*:\s*"([a-zA-Z0-9]+)"/) ||
+                          text.match(/"idScript"\s*:\s*"([a-zA-Z0-9]+)"/) ||
+                          text.match(/"scriptIdPart"\s*:\s*"([a-zA-Z0-9]+)"/) ||
+                          text.match(/\/script\/([a-zA-Z0-9]+)/) ||
+                          text.match(/"publishedUrl"\s*:\s*"[^"]*\/script\/([a-zA-Z0-9]+)/)
+
+          if (idMatch && !capturedScriptId) {
+            capturedScriptId = idMatch[1]
+            console.log(`[Warm Validate] Captured script ID from API: ${capturedScriptId}`)
+          }
+        }
+      } catch {
+        // Ignore errors
+      }
+    }
+    // Track handler at function level for cleanup in error paths
+    registeredResponseHandler = responseHandler
+    page.on('response', responseHandler)
+
+    // Get browser context to listen for new tabs
+    const browser = page.browser()
+    let newScriptPage: import('puppeteer-core').Page | null = null
+
+    // Set up listener for new page (TradingView opens new tab with published script)
+    const newPagePromise = new Promise<import('puppeteer-core').Page | null>((resolve) => {
+      const timeout = setTimeout(() => {
+        console.log('[Warm Validate] No new tab opened within timeout')
+        resolve(null)
+      }, 15000)
+
+      browser?.once('targetcreated', async (target) => {
+        clearTimeout(timeout)
+        try {
+          const newPage = await target.page()
+          if (newPage) {
+            console.log('[Warm Validate] New tab detected')
+            resolve(newPage)
+          } else {
+            resolve(null)
+          }
+        } catch (e) {
+          console.log('[Warm Validate] Error getting new tab:', e)
+          resolve(null)
+        }
+      })
+    })
+
+    // Click submit button
+    const submitSelectors = [
+      'button[type="submit"]',
+      'button[data-name="submit"]',
+      'button:has-text("Publish")',
+    ]
+
+    let submitClicked = false
+    for (const selector of submitSelectors) {
+      try {
+        const btn = await page.$(selector)
+        if (btn) {
+          await btn.click()
+          submitClicked = true
+          console.log(`[Warm Validate] Clicked submit: ${selector}`)
+          break
+        }
+      } catch {
+        // Try next
+      }
+    }
+
+    if (!submitClicked) {
+      // Try clicking any button with "Publish" text
+      submitClicked = await page.evaluate(() => {
+        const buttons = Array.from(document.querySelectorAll('button'))
+        for (const btn of buttons) {
+          const text = btn.textContent?.toLowerCase() || ''
+          if (text.includes('publish') && !text.includes('cancel')) {
+            btn.click()
+            return true
+          }
+        }
+        return false
+      })
+      if (submitClicked) {
+        console.log('[Warm Validate] Clicked submit via text search')
+      }
+    }
+
+    // Wait for new tab with published script URL OR dialog to close with success
+    console.log('[Warm Validate] Waiting for new tab with published script...')
+
+    // Start concurrent checks
+    const dialogClosedPromise = (async () => {
+      // Wait for publish dialog to close (up to 20s)
+      for (let i = 0; i < 20; i++) {
+        await delay(1000)
+        const dialogVisible = await page.evaluate(() => {
+          const dialog = document.querySelector('[data-dialog-name="publish-script"], [data-name="publish-dialog"], [class*="publish-dialog"]')
+          return dialog !== null && (dialog as HTMLElement).offsetParent !== null
+        }).catch(() => true)
+
+        if (!dialogVisible) {
+          console.log('[Warm Validate] Publish dialog closed after submit')
+          // Look for success notification or script link
+          const scriptUrl = await page.evaluate(() => {
+            // Check for toast notifications with success message
+            const toasts = document.querySelectorAll('[class*="toast"], [class*="notification"], [class*="snackbar"]')
+            for (const toast of toasts) {
+              const link = toast.querySelector('a[href*="/script/"]') as HTMLAnchorElement
+              if (link?.href) return link.href
+            }
+
+            // Check for any newly appeared script links
+            const scriptLinks = document.querySelectorAll('a[href*="/script/"]')
+            for (const link of scriptLinks) {
+              const href = (link as HTMLAnchorElement).href
+              if (href.includes('tradingview.com/script/')) {
+                return href
+              }
+            }
+            return null
+          }).catch(() => null)
+
+          if (scriptUrl) {
+            return { source: 'dialog-closed', url: scriptUrl }
+          }
+
+          // Dialog closed but no URL found yet - continue checking
+          return { source: 'dialog-closed', url: null }
+        }
+      }
+      return { source: 'timeout', url: null }
+    })()
+
+    newScriptPage = await newPagePromise
+
+    if (newScriptPage) {
+      try {
+        await newScriptPage.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 10000 }).catch(() => {})
+        await delay(1000)
+        const newTabUrl = newScriptPage.url()
+        console.log(`[Warm Validate] New tab URL: ${newTabUrl}`)
+
+        if (newTabUrl.includes('/script/')) {
+          const totalTime = Date.now() - startTime
+          console.log(`[Warm Validate] Published successfully in ${totalTime}ms: ${newTabUrl}`)
+          // Close the new tab since we got the URL
+          await newScriptPage.close().catch(() => {})
+          return {
+            validation: validationResult,
+            publish: { success: true, indicatorUrl: newTabUrl },
+          }
+        }
+        // Close the new tab if it wasn't the script page
+        await newScriptPage.close().catch(() => {})
+      } catch (e) {
+        console.log('[Warm Validate] Error checking new tab:', e)
+        await newScriptPage.close().catch(() => {})
+      }
+    }
+
+    // Check if we captured script ID from network response
+    if (capturedScriptId) {
+      const indicatorUrl = `https://www.tradingview.com/script/${capturedScriptId}/`
+      const totalTime = Date.now() - startTime
+      console.log(`[Warm Validate] Published successfully via API capture in ${totalTime}ms: ${indicatorUrl}`)
+      page.off('response', responseHandler)
+      return {
+        validation: validationResult,
+        publish: { success: true, indicatorUrl },
+      }
+    }
+
+    // Fallback: Try multiple times to find the URL in the current page
+    console.log('[Warm Validate] No URL from new tab or API, checking current page...')
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await delay(2000)
+
+      // Check captured script ID again (might have been set during delay)
+      if (capturedScriptId) {
+        const indicatorUrl = `https://www.tradingview.com/script/${capturedScriptId}/`
+        const totalTime = Date.now() - startTime
+        console.log(`[Warm Validate] Published successfully via API capture in ${totalTime}ms: ${indicatorUrl}`)
+        page.off('response', responseHandler)
+        return {
+          validation: validationResult,
+          publish: { success: true, indicatorUrl },
+        }
+      }
+
+      // Check if we got redirected to the script page
+      const currentUrl = page.url()
+      console.log(`[Warm Validate] Attempt ${attempt + 1}: Current URL: ${currentUrl}`)
+
+      const indicatorMatch = currentUrl.match(/tradingview\.com\/script\/([^/]+)/)
+      if (indicatorMatch) {
+        const indicatorUrl = `https://www.tradingview.com/script/${indicatorMatch[1]}/`
+        const totalTime = Date.now() - startTime
+        console.log(`[Warm Validate] Published successfully in ${totalTime}ms: ${indicatorUrl}`)
+        return {
+          validation: validationResult,
+          publish: { success: true, indicatorUrl },
+        }
+      }
+
+      // Try to find script link in page - check toasts, dialogs, and body text
+      const indicatorUrl = await page.evaluate(() => {
+        // Check toast notifications first (TradingView shows success toasts)
+        const toasts = document.querySelectorAll('[class*="toast"], [class*="notification"], [class*="snackbar"], [data-name*="toast"]')
+        for (const toast of toasts) {
+          const link = toast.querySelector('a[href*="/script/"]') as HTMLAnchorElement
+          if (link?.href) return link.href
+          const text = toast.textContent || ''
+          const match = text.match(/tradingview\.com\/script\/([a-zA-Z0-9]+)/)
+          if (match) return `https://www.tradingview.com/script/${match[1]}/`
+        }
+
+        // Check any visible dialogs
+        const dialogs = document.querySelectorAll('[class*="dialog"], [role="dialog"], [data-dialog]')
+        for (const dialog of dialogs) {
+          const link = dialog.querySelector('a[href*="/script/"]') as HTMLAnchorElement
+          if (link?.href) return link.href
+        }
+
+        // Check all links on page
+        const links = Array.from(document.querySelectorAll('a[href*="/script/"]'))
+        for (const link of links) {
+          const href = (link as HTMLAnchorElement).href
+          if (href.includes('tradingview.com/script/')) {
+            return href
+          }
+        }
+
+        // Look for success message containing URL in body text
+        const successText = document.body.innerText
+        const urlMatch = successText.match(/tradingview\.com\/script\/([a-zA-Z0-9]+)/)
+        if (urlMatch) {
+          return `https://www.tradingview.com/script/${urlMatch[1]}/`
+        }
+
+        return null
+      })
+
+      if (indicatorUrl) {
+        const totalTime = Date.now() - startTime
+        console.log(`[Warm Validate] Published in ${totalTime}ms: ${indicatorUrl}`)
+        return {
+          validation: validationResult,
+          publish: { success: true, indicatorUrl },
+        }
+      }
+    }
+
+    // Check if dialog closed with a URL
+    const dialogResult = await dialogClosedPromise
+    if (dialogResult.url) {
+      const totalTime = Date.now() - startTime
+      console.log(`[Warm Validate] Found URL after dialog closed in ${totalTime}ms: ${dialogResult.url}`)
+      page.off('response', responseHandler)
+      return {
+        validation: validationResult,
+        publish: { success: true, indicatorUrl: dialogResult.url },
+      }
+    }
+    console.log(`[Warm Validate] Dialog check result: ${dialogResult.source}, url: ${dialogResult.url}`)
+
+    // If dialog closed successfully, try to get script URL via lightweight fetch
+    if (dialogResult.source === 'dialog-closed') {
+      console.log(`[Warm Validate] Dialog closed, trying lightweight script lookup...`)
+
+      // Try to get the most recent script via TradingView's internal API
+      const serviceAccountUsername = process.env.TV_SERVICE_ACCOUNT_USERNAME || 'lirex14'
+      const scriptUrl = await page.evaluate(async (username) => {
+        try {
+          // Try TradingView's user scripts API first
+          const apiResponse = await fetch(`https://www.tradingview.com/u-scripts/${username}/?sort=recent&count=1`, {
+            credentials: 'include',
+          })
+          if (apiResponse.ok) {
+            const apiText = await apiResponse.text()
+            // Look for script ID in the response
+            const scriptIdMatch = apiText.match(/\/script\/([a-zA-Z0-9]+)/)
+            if (scriptIdMatch) {
+              return { url: `https://www.tradingview.com/script/${scriptIdMatch[1]}/`, source: 'api' }
+            }
+          }
+
+          // Fallback to profile page HTML
+          const response = await fetch(`https://www.tradingview.com/u/${username}/`, {
+            credentials: 'include',
+          })
+          const html = await response.text()
+
+          // Log what we got (truncated)
+          console.log('Profile HTML length:', html.length, 'First 500 chars:', html.slice(0, 500))
+
+          // Try to find script in initial data (TradingView often embeds data in window.__INITIAL_STATE__)
+          const initialStateMatch = html.match(/window\.__INITIAL_STATE__\s*=\s*({[^<]+})/s)
+          if (initialStateMatch) {
+            try {
+              const state = JSON.parse(initialStateMatch[1])
+              // Look for scripts in the state
+              const stateStr = JSON.stringify(state)
+              const scriptMatch = stateStr.match(/\/script\/([a-zA-Z0-9]+)/)
+              if (scriptMatch) {
+                return { url: `https://www.tradingview.com/script/${scriptMatch[1]}/`, source: 'initial-state' }
+              }
+            } catch (e) {
+              // JSON parse failed
+            }
+          }
+
+          // Try to find script link directly in HTML
+          const scriptMatch = html.match(/href="(\/script\/[a-zA-Z0-9]+[^"]*)"/)
+          if (scriptMatch) {
+            return { url: `https://www.tradingview.com${scriptMatch[1]}`, source: 'html-href' }
+          }
+
+          // Try alternate patterns
+          const altMatch = html.match(/tradingview\.com\/script\/([a-zA-Z0-9]+)/)
+          if (altMatch) {
+            return { url: `https://www.tradingview.com/script/${altMatch[1]}/`, source: 'html-text' }
+          }
+
+          return null
+        } catch (e) {
+          console.error('Fetch error:', e)
+          return null
+        }
+      }, serviceAccountUsername)
+
+      if (scriptUrl) {
+        const totalTime = Date.now() - startTime
+        console.log(`[Warm Validate] Found script URL via ${scriptUrl.source} in ${totalTime}ms: ${scriptUrl.url}`)
+        page.off('response', responseHandler)
+        return {
+          validation: validationResult,
+          publish: { success: true, indicatorUrl: scriptUrl.url },
+        }
+      }
+
+      console.log('[Warm Validate] Fetch lookup failed, trying profile page fallback...')
+    }
+
+    // Only try profile if dialog didn't close (timeout or unknown state)
+    console.log('[Warm Validate] Trying to find script URL from user profile...')
+    try {
+      // Create a new tab for profile navigation to avoid disrupting current page
+      const browser = page.browser()
+      const profilePage = await browser?.newPage()
+
+      if (profilePage) {
+        // Inject cookies into the new page
+        const cookies = await page.cookies()
+        if (cookies.length > 0) {
+          await profilePage.setCookie(...cookies)
+        }
+
+        const serviceAccountProfile = process.env.TV_SERVICE_ACCOUNT_PROFILE || 'https://www.tradingview.com/u/lirex14/#published-scripts'
+        console.log(`[Warm Validate] Opening profile page: ${serviceAccountProfile}`)
+
+        await profilePage.goto(serviceAccountProfile, {
+          waitUntil: 'domcontentloaded',
+          timeout: 10000,
+        })
+
+        // Wait for script cards to load - shorter timeout since this is a fallback
+        console.log('[Warm Validate] Profile page loaded, waiting for script links...')
+        await profilePage.waitForSelector('a[href*="/script/"]', { timeout: 8000 }).catch(() => {
+          console.log('[Warm Validate] Script links not found within timeout')
+        })
+        await delay(1000)
+
+        // Look for the most recent script (should be at the top)
+        const profileScriptUrl = await profilePage.evaluate(() => {
+          // Find all script links
+          const scriptLinks = Array.from(document.querySelectorAll('a[href*="/script/"]'))
+          for (const link of scriptLinks) {
+            const href = (link as HTMLAnchorElement).href
+            // Filter out non-script URLs
+            if (href.includes('/script/') && !href.includes('/script/library/')) {
+              return href
+            }
+          }
+          return null
+        })
+
+        await profilePage.close()
+
+        if (profileScriptUrl) {
+          const totalTime = Date.now() - startTime
+          console.log(`[Warm Validate] Found script URL from profile in ${totalTime}ms: ${profileScriptUrl}`)
+          page.off('response', responseHandler)
+          return {
+            validation: validationResult,
+            publish: { success: true, indicatorUrl: profileScriptUrl },
+          }
+        }
+      }
+    } catch (e) {
+      console.log('[Warm Validate] Failed to get script URL from profile:', e)
+    }
+
+    // Final check for captured script ID
+    if (capturedScriptId) {
+      const indicatorUrl = `https://www.tradingview.com/script/${capturedScriptId}/`
+      const totalTime = Date.now() - startTime
+      console.log(`[Warm Validate] Published successfully via delayed API capture in ${totalTime}ms: ${indicatorUrl}`)
+      page.off('response', responseHandler)
+      return {
+        validation: validationResult,
+        publish: { success: true, indicatorUrl },
+      }
+    }
+
+    const totalTime = Date.now() - startTime
+    console.log(`[Warm Validate] Publish completed in ${totalTime}ms (URL not captured)`)
+    await page.screenshot({ path: '/tmp/warm-publish-no-url.png' }).catch(() => {})
+    console.log('[Warm Validate] Screenshot saved to /tmp/warm-publish-no-url.png')
+    page.off('response', responseHandler)
+    return {
+      validation: validationResult,
+      publish: { success: false, error: 'Could not retrieve script URL after publish. The script may have been published - check your TradingView profile.' },
+    }
+  } catch (error) {
+    console.error('[Warm Validate] Error:', error)
+    // Clean up response handler to prevent memory leak
+    if (registeredResponseHandler) {
+      page.off('response', registeredResponseHandler)
+    }
+    return {
+      validation: {
+        isValid: false,
+        errors: [
+          {
+            line: 0,
+            message: `Warm session validation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            type: 'error',
+          },
+        ],
+        rawOutput: '',
+      },
+    }
+  }
+}
+
+/**
+ * Validate and optionally publish a Pine Script in a single browser session
+ * This is more efficient than calling validate and publish separately as it
+ * reuses the same browser session, saving ~17s of overhead.
+ */
+export async function validateAndPublishPineScript(
+  credentials: TVCredentials,
+  script: string,
+  publishOptions?: {
+    title: string
+    description: string
+    visibility?: 'public' | 'private'
+  },
+  requestId?: string
+): Promise<ValidateAndPublishResult> {
+  const reqId = requestId || randomUUID().slice(0, 8)
+
+  // Dev mode bypass
+  if (DEV_BYPASS) {
+    console.log(`[TV Combined:${reqId}] Dev bypass: Simulating validate + publish`)
+    const fakeId = Math.random().toString(36).substring(7)
+    return {
+      validation: {
+        isValid: true,
+        errors: [],
+        rawOutput: '[Dev Mode] Validation bypassed',
+      },
+      publish: publishOptions
+        ? {
+            success: true,
+            indicatorUrl: `https://www.tradingview.com/script/${fakeId}/dev-test-indicator`,
+          }
+        : undefined,
+    }
+  }
+
+  // Acquire lock to serialize Browserless access (plan limits to 1 concurrent session)
+  await acquireBrowserlessLock(reqId)
+
+  console.log(`[TV Combined:${reqId}] Using /chart/ page for validation + publish (single session)`)
+  let session: BrowserlessSession | null = null
+
+  try {
+    session = await createBrowserSession()
+    const { page } = session
+
+    // Inject cookies
+    const cookies = parseTVCookies(credentials)
+    await injectCookies(page, cookies)
+
+    // Navigate to TradingView chart
+    const navigated = await navigateTo(page, TV_URLS.chart)
+    if (!navigated) {
+      throw new Error('Failed to navigate to TradingView')
+    }
+
+    console.log('[TV Combined] Checking if Pine Editor is already open...')
+    await delay(3000) // Wait for page to fully load
+
+    // Check if Pine Editor is already open
+    const pineEditorVisible = await waitForElement(page, TV_SELECTORS.pineEditor.container, 5000)
+    if (!pineEditorVisible) {
+      console.log('[TV Combined] Pine Editor not open, looking for open button...')
+
+      // Try multiple selectors for the Pine Editor button
+      const editorButtonSelectors = [
+        '[data-name="open-pine-editor"]',
+        'button[title="Pine"]',
+        'button[aria-label="Pine"]',
+        'button[title*="Pine"]',
+        'button[aria-label*="Pine"]',
+        '[data-role="button"][title*="Pine"]',
+      ]
+
+      let buttonFound = false
+      for (const selector of editorButtonSelectors) {
+        try {
+          const button = await page.$(selector)
+          if (button) {
+            console.log(`[TV Combined] Found Pine Editor button with selector: ${selector}`)
+            await button.click()
+            buttonFound = true
+            break
+          }
+        } catch (e) {
+          console.log(`[TV Combined] Selector ${selector} failed, trying next...`)
+        }
+      }
+
+      if (!buttonFound) {
+        // Try finding by title attribute containing "Pine"
+        const clicked = await page.evaluate(() => {
+          const buttons = Array.from(document.querySelectorAll('button, div[role="button"], [role="button"]'))
+          const pineBtn = buttons.find(btn => {
+            const title = btn.getAttribute('title')
+            const ariaLabel = btn.getAttribute('aria-label')
+            return (title && title.toLowerCase().includes('pine')) ||
+                   (ariaLabel && ariaLabel.toLowerCase().includes('pine'))
+          })
+          if (pineBtn) {
+            (pineBtn as HTMLElement).click()
+            return true
+          }
+          return false
+        })
+
+        if (clicked) {
+          console.log('[TV Combined] Clicked Pine button via title/aria-label search')
+          buttonFound = true
+        }
+      }
+
+      // Wait for Pine Editor to appear - try all selectors in parallel
+      console.log('[TV Combined] Waiting for Pine Editor to load...')
+
+      // Try multiple selectors for Pine Editor container - in parallel
+      const pineEditorSelectors = [
+        '[data-name="pine-editor"]',
+        '.pine-editor-container',
+        '[data-role="panel-Pine"]',
+        '[id*="pine"]',
+        '.monaco-editor',
+      ]
+
+      // Race all selectors - first one to match wins
+      let editorOpened = false
+      const selectorPromises = pineEditorSelectors.map(async (selector) => {
+        const found = await waitForElement(page, selector, 15000)
+        if (found) return selector
+        return null
+      })
+
+      const winningSelector = await Promise.race([
+        Promise.any(selectorPromises.map(p => p.then(s => s ? s : Promise.reject()))).catch(() => null),
+        delay(15000).then(() => null),
+      ])
+
+      if (winningSelector) {
+        console.log(`[TV Combined] Pine Editor found with selector: ${winningSelector}`)
+        editorOpened = true
+      }
+
+      if (!editorOpened) {
+        await page.screenshot({ path: '/tmp/tv-combined-pine-editor-not-found.png' })
+        console.log('[TV Combined] Screenshot saved to /tmp/tv-combined-pine-editor-not-found.png')
+        throw new Error('Could not open Pine Editor')
+      }
+      console.log('[TV Combined] Pine Editor opened successfully')
+    } else {
+      console.log('[TV Combined] Pine Editor already open')
+    }
+
+    // Wait for Monaco editor to be ready
+    console.log('[TV Combined] Waiting for Monaco editor...')
+    await waitForElement(page, TV_SELECTORS.pineEditor.editorArea, 10000)
+    await delay(500)
+
+    // Insert script via clipboard paste
+    console.log('[TV Combined] Inserting script via clipboard paste...')
+    await page.click('.monaco-editor')
+    await page.keyboard.down('Control')
+    await page.keyboard.press('a')
+    await page.keyboard.up('Control')
+    await delay(100)
+    await page.evaluate((text) => navigator.clipboard.writeText(text), script)
+    await page.keyboard.down('Control')
+    await page.keyboard.press('v')
+    await page.keyboard.up('Control')
+    console.log('[TV Combined] Script inserted via clipboard paste')
+
+    // Wait for compilation
+    await delay(3000)
+
+    // Check console panel for errors
+    const errors = await page.evaluate((selectors) => {
+      const consolePanel = document.querySelector(selectors.consolePanel)
+      if (!consolePanel) return []
+
+      const errorLines = consolePanel.querySelectorAll(selectors.errorLine)
+      const warningLines = consolePanel.querySelectorAll(selectors.warningLine)
+
+      const parseConsoleLine = (element: Element, type: 'error' | 'warning') => {
+        const text = element.textContent || ''
+        const lineMatch = text.match(/line (\d+)/i)
+        return {
+          line: lineMatch ? parseInt(lineMatch[1], 10) : 0,
+          message: text.trim(),
+          type,
+        }
+      }
+
+      return [
+        ...Array.from(errorLines).map((el) => parseConsoleLine(el, 'error')),
+        ...Array.from(warningLines).map((el) => parseConsoleLine(el, 'warning')),
+      ]
+    }, TV_SELECTORS.pineEditor)
+
+    // Get raw console output
+    const rawOutput = await page.evaluate((selector) => {
+      const panel = document.querySelector(selector)
+      return panel?.textContent || ''
+    }, TV_SELECTORS.pineEditor.consolePanel)
+
+    const validationResult: ValidationResult = {
+      isValid: errors.filter((e) => e.type === 'error').length === 0,
+      errors,
+      rawOutput,
+    }
+
+    console.log(`[TV Combined:${reqId}] Validation complete: isValid=${validationResult.isValid}`)
+
+    // If validation failed or no publish options, return just validation result
+    if (!validationResult.isValid || !publishOptions) {
+      return { validation: validationResult }
+    }
+
+    // === PUBLISH PHASE (reusing same session) ===
+    console.log(`[TV Combined:${reqId}] Validation passed, proceeding to publish in same session...`)
+
+    const { title, description, visibility = 'public' } = publishOptions
+
+    // Set up network response capture to get script ID from API response
+    let capturedScriptId: string | null = null
+    const responseHandler = async (response: import('puppeteer-core').HTTPResponse) => {
+      try {
+        const url = response.url()
+        const status = response.status()
+        if (status < 200 || status >= 300) return
+        if (url.includes('.js') || url.includes('.css') || url.includes('.png')) return
+
+        // Check for publish-related API responses
+        if (url.includes('/pine_facade/') || url.includes('/script/') || url.includes('publish')) {
+          const contentType = response.headers()['content-type'] || ''
+          if (contentType.includes('application/json') || contentType.includes('text/')) {
+            const text = await response.text().catch(() => '')
+            // Look for script ID patterns in response
+            const idMatch = text.match(/"id"\s*:\s*"([a-zA-Z0-9]+)"/) ||
+                          text.match(/"scriptId"\s*:\s*"([a-zA-Z0-9]+)"/) ||
+                          text.match(/"idScript"\s*:\s*"([a-zA-Z0-9]+)"/) ||
+                          text.match(/\/script\/([a-zA-Z0-9]+)/) ||
+                          text.match(/"publishedUrl"\s*:\s*"[^"]*\/script\/([a-zA-Z0-9]+)/)
+            if (idMatch && !capturedScriptId) {
+              capturedScriptId = idMatch[1]
+              console.log(`[TV Combined:${reqId}] Captured script ID from API: ${capturedScriptId}`)
+            }
+          }
+        }
+      } catch {
+        // Ignore errors
+      }
+    }
+    page.on('response', responseHandler)
+
+    // Click "Add to chart" to verify the script compiles correctly
+    console.log('[TV Combined] Clicking "Add to chart" to verify script...')
+    const addToChartSelectors = [
+      '[data-name="add-script-to-chart"]',
+      '[aria-label*="Add to chart" i]',
+      '[title*="Add to chart" i]',
+      'button[class*="apply" i]',
+    ]
+
+    let addToChartClicked = false
+    for (const selector of addToChartSelectors) {
+      try {
+        const btn = await page.$(selector)
+        if (btn) {
+          await btn.click()
+          addToChartClicked = true
+          console.log(`[TV Combined] Clicked "Add to chart": ${selector}`)
+          break
+        }
+      } catch {
+        // Try next selector
+      }
+    }
+
+    if (!addToChartClicked) {
+      addToChartClicked = await page.evaluate(() => {
+        const buttons = Array.from(document.querySelectorAll('button, [role="button"]'))
+        const btn = buttons.find(b => {
+          const text = b.textContent?.toLowerCase() || ''
+          return text.includes('add to chart') || text.includes('apply')
+        })
+        if (btn) {
+          (btn as HTMLElement).click()
+          return true
+        }
+        return false
+      })
+      if (addToChartClicked) {
+        console.log('[TV Combined] Clicked "Add to chart" via text search')
+      }
+    }
+
+    await delay(1500)
+
+    // Click publish button
+    console.log('[TV Combined] Looking for publish button...')
+    const publishButtonSelectors = [
+      TV_SELECTORS.publish.button,
+      '[data-name="publish-script-button"]',
+      '[data-name="save-publish-button"]',
+      '[aria-label*="Publish" i]',
+      '[title*="Publish" i]',
+      'button[class*="publish" i]',
+    ]
+
+    let publishClicked = false
+    for (const selector of publishButtonSelectors) {
+      try {
+        const btn = await page.$(selector)
+        if (btn) {
+          await btn.click()
+          publishClicked = true
+          console.log(`[TV Combined] Clicked publish button: ${selector}`)
+          break
+        }
+      } catch {
+        // Try next selector
+      }
+    }
+
+    if (!publishClicked) {
+      publishClicked = await page.evaluate(() => {
+        const buttons = Array.from(document.querySelectorAll('button, [role="button"]'))
+        const publishBtn = buttons.find(btn => {
+          const text = btn.textContent?.toLowerCase() || ''
+          const ariaLabel = btn.getAttribute('aria-label')?.toLowerCase() || ''
+          return text.includes('publish') || ariaLabel.includes('publish')
+        })
+        if (publishBtn) {
+          (publishBtn as HTMLElement).click()
+          return true
+        }
+        return false
+      })
+      if (publishClicked) {
+        console.log('[TV Combined] Clicked publish button via text search')
+      }
+    }
+
+    if (!publishClicked) {
+      await page.screenshot({ path: '/tmp/tv-combined-publish-no-button.png' })
+      console.log('[TV Combined] Screenshot saved to /tmp/tv-combined-publish-no-button.png')
+      return {
+        validation: validationResult,
+        publish: { success: false, error: 'Could not find publish button' },
+      }
+    }
+
+    // Wait for publish dialog
+    await waitForElement(page, TV_SELECTORS.publish.dialog, 10000)
+
+    // === STEP 1: Fill in title and description ===
+    console.log('[TV Combined] Step 1: Filling title and description...')
+    await delay(500)
+
+    // Fill title
+    const titleSelectors = [TV_SELECTORS.publish.titleInput, 'input[name="title"]', 'input[placeholder*="title" i]', 'input[type="text"]']
+    for (const sel of titleSelectors) {
+      try {
+        const input = await page.$(sel)
+        if (input) {
+          await input.click()
+          await delay(100)
+          await page.keyboard.down('Control')
+          await page.keyboard.press('a')
+          await page.keyboard.up('Control')
+          await delay(50)
+          await page.keyboard.type(title, { delay: 10 })
+          console.log(`[TV Combined] Title filled: "${title}" using: ${sel}`)
+          break
+        }
+      } catch { /* try next */ }
+    }
+
+    // Fill description
+    const descriptionText = description || title
+    console.log(`[TV Combined] Will fill description with: "${descriptionText}"`)
+
+    console.log('[TV Combined] Trying Tab key to move to description...')
+    await page.keyboard.press('Tab')
+    await delay(150)
+    await page.keyboard.type(descriptionText, { delay: 5 })
+
+    let descFilled = await page.evaluate(() => {
+      const editables = Array.from(document.querySelectorAll('[contenteditable="true"]'))
+      return editables.some(el => el.textContent && el.textContent.length > 0)
+    })
+
+    if (descFilled) {
+      console.log('[TV Combined] Description filled via Tab key')
+    } else {
+      console.log('[TV Combined] Tab method may have failed, trying direct click...')
+      const clicked = await page.evaluate(() => {
+        const editables = Array.from(document.querySelectorAll('[contenteditable="true"]'))
+        for (const el of editables) {
+          const rect = el.getBoundingClientRect()
+          if (rect.height > 50 && rect.top > 100) {
+            (el as HTMLElement).click()
+            (el as HTMLElement).focus()
+            return true
+          }
+        }
+        return false
+      })
+
+      if (clicked) {
+        await delay(200)
+        await page.keyboard.type(descriptionText, { delay: 5 })
+        descFilled = true
+        console.log('[TV Combined] Description filled via direct click')
+      }
+    }
+
+    // Click "Continue" button to go to step 2
+    console.log('[TV Combined] Clicking Continue to go to step 2...')
+    let continuedToStep2 = await page.evaluate(() => {
+      const buttons = Array.from(document.querySelectorAll('button'))
+      const btn = buttons.find(b => b.textContent?.toLowerCase().includes('continue'))
+      if (btn) {
+        btn.click()
+        return true
+      }
+      return false
+    })
+    if (continuedToStep2) {
+      console.log('[TV Combined] Clicked Continue via text search')
+    }
+
+    await delay(1000)
+
+    // === STEP 2: Set visibility and final submit ===
+    console.log('[TV Combined] Step 2: Setting visibility options...')
+
+    // Dismiss any popup overlays
+    console.log('[TV Combined] Checking for popup overlays...')
+    await page.evaluate(() => {
+      const closeButtons = document.querySelectorAll('[class*="close"], [aria-label*="close" i], [class*="dismiss"]')
+      for (const btn of closeButtons) {
+        const rect = (btn as HTMLElement).getBoundingClientRect()
+        if (rect.width > 0 && rect.height > 0 && rect.width < 50) {
+          (btn as HTMLElement).click()
+        }
+      }
+    })
+    await delay(200)
+
+    // Select visibility
+    console.log(`[TV Combined] Selecting ${visibility} visibility...`)
+    const visibilitySelected = await page.evaluate((targetVisibility) => {
+      const buttons = Array.from(document.querySelectorAll('button, [role="button"], [class*="tab"], label'))
+      for (const btn of buttons) {
+        const text = btn.textContent?.toLowerCase() || ''
+        if (text === targetVisibility || text.includes(targetVisibility)) {
+          (btn as HTMLElement).click()
+          return true
+        }
+      }
+
+      const radios = Array.from(document.querySelectorAll('input[type="radio"]'))
+      for (const radio of radios) {
+        const value = (radio as HTMLInputElement).value?.toLowerCase() || ''
+        const label = radio.closest('label')?.textContent?.toLowerCase() || ''
+        if (value === targetVisibility || label.includes(targetVisibility)) {
+          (radio as HTMLInputElement).click()
+          return true
+        }
+      }
+
+      return false
+    }, visibility)
+
+    if (visibilitySelected) {
+      console.log(`[TV Combined] Selected ${visibility} visibility`)
+    }
+    await delay(150)
+
+    // Check required checkboxes
+    const checkboxes = await page.$$('input[type="checkbox"]:not(:checked)')
+    for (const checkbox of checkboxes) {
+      try {
+        await checkbox.click()
+        console.log('[TV Combined] Checked a required checkbox')
+      } catch { /* ignore */ }
+    }
+
+    await delay(200)
+
+    // Set up listener for new tabs
+    const browser = page.browser()
+    let newScriptPage: typeof page | null = null
+
+    const newPagePromise = new Promise<typeof page | null>((resolve) => {
+      const timeout = setTimeout(() => resolve(null), 15000)
+      browser.once('targetcreated', async (target) => {
+        if (target.type() === 'page') {
+          clearTimeout(timeout)
+          const newPage = await target.page()
+          resolve(newPage || null)
+        }
+      })
+    })
+
+    // Final submit
+    console.log('[TV Combined] Clicking final Publish button...')
+    let submitted = await page.evaluate(() => {
+      const buttons = Array.from(document.querySelectorAll('button'))
+      const btn = buttons.find(b => {
+        const text = b.textContent?.toLowerCase() || ''
+        return text.includes('publish') && text.includes('script')
+      })
+      if (btn) {
+        btn.click()
+        return true
+      }
+      return false
+    })
+
+    if (submitted) {
+      console.log('[TV Combined] Clicked publish script button')
+    } else {
+      submitted = await page.evaluate(() => {
+        const buttons = Array.from(document.querySelectorAll('button'))
+        const btn = buttons.find(b => {
+          const text = b.textContent?.toLowerCase() || ''
+          return text.includes('publish') && !text.includes('continue')
+        })
+        if (btn) {
+          btn.click()
+          return true
+        }
+        return false
+      })
+      if (submitted) {
+        console.log('[TV Combined] Clicked Publish via text search')
+      }
+    }
+
+    if (!submitted) {
+      await page.screenshot({ path: '/tmp/tv-combined-publish-step2-failed.png' })
+      return {
+        validation: validationResult,
+        publish: { success: false, error: 'Could not find final Publish button' },
+      }
+    }
+
+    // Wait for publish to complete
+    console.log('[TV Combined] Waiting for publish to complete...')
+    console.log('[TV Combined] Waiting for new tab with published script...')
+    newScriptPage = await newPagePromise
+
+    if (newScriptPage) {
+      try {
+        await newScriptPage.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 10000 }).catch(() => {})
+        await delay(1000)
+        const newTabUrl = newScriptPage.url()
+        console.log(`[TV Combined] New tab opened: ${newTabUrl}`)
+
+        if (newTabUrl.includes('/script/')) {
+          console.log(`[TV Combined] Found script URL in new tab: ${newTabUrl}`)
+          await newScriptPage.close().catch(() => {})
+          return {
+            validation: validationResult,
+            publish: { success: true, indicatorUrl: newTabUrl },
+          }
+        }
+        await newScriptPage.close().catch(() => {})
+      } catch (e) {
+        console.log('[TV Combined] Error checking new tab:', e)
+      }
+    } else {
+      console.log('[TV Combined] No new tab detected, checking current page...')
+    }
+
+    // Fallback: Try to find the indicator URL
+    // Wrap in try-catch because page frame may be detached after new tab opens
+    try {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await delay(2000)
+
+        const currentUrl = page.url()
+        console.log(`[TV Combined] Attempt ${attempt + 1}: Current URL: ${currentUrl}`)
+
+        const indicatorMatch = currentUrl.match(/tradingview\.com\/script\/([^/]+)/)
+        if (indicatorMatch) {
+          return {
+            validation: validationResult,
+            publish: { success: true, indicatorUrl: `https://www.tradingview.com/script/${indicatorMatch[1]}/` },
+          }
+        }
+
+        const indicatorUrl = await page.evaluate(() => {
+          const links = Array.from(document.querySelectorAll('a[href*="/script/"]'))
+          for (const link of links) {
+            const href = (link as HTMLAnchorElement).href
+            if (href.includes('tradingview.com/script/')) {
+              return href
+            }
+          }
+          return null
+        })
+
+        if (indicatorUrl) {
+          return {
+            validation: validationResult,
+            publish: { success: true, indicatorUrl },
+          }
+        }
+      }
+    } catch (e) {
+      // Page frame likely detached after new tab opened - publish probably succeeded
+      console.log('[TV Combined] Page frame detached, checking for captured script ID...')
+      page.off('response', responseHandler)
+
+      if (capturedScriptId) {
+        const indicatorUrl = `https://www.tradingview.com/script/${capturedScriptId}/`
+        console.log(`[TV Combined:${reqId}] Published successfully via captured ID: ${indicatorUrl}`)
+        return {
+          validation: validationResult,
+          publish: { success: true, indicatorUrl },
+        }
+      }
+
+      console.log('[TV Combined] No script ID captured after frame detachment - publish status unknown')
+      return {
+        validation: validationResult,
+        publish: { success: false, error: 'Frame detached before URL could be captured. The script may have been published - check your TradingView profile.' },
+      }
+    }
+
+    // Fallback: Navigate to user's scripts page
+    console.log('[TV Combined] Trying to find script URL from user profile...')
+    try {
+      await page.goto('https://www.tradingview.com/u/#published-scripts', {
+        waitUntil: 'networkidle2',
+        timeout: 30000,
+      })
+      await delay(2000)
+
+      const scriptUrl = await page.evaluate(() => {
+        const scriptLinks = Array.from(document.querySelectorAll('a[href*="/script/"]'))
+        for (const link of scriptLinks) {
+          const href = (link as HTMLAnchorElement).href
+          if (href.includes('/script/')) {
+            return href
+          }
+        }
+        return null
+      })
+
+      if (scriptUrl) {
+        console.log(`[TV Combined] Found script URL from profile: ${scriptUrl}`)
+        return {
+          validation: validationResult,
+          publish: { success: true, indicatorUrl: scriptUrl },
+        }
+      }
+    } catch (e) {
+      console.log('[TV Combined] Failed to navigate to profile:', e)
+    }
+
+    // Final check for captured script ID
+    page.off('response', responseHandler)
+    if (capturedScriptId) {
+      const indicatorUrl = `https://www.tradingview.com/script/${capturedScriptId}/`
+      console.log(`[TV Combined:${reqId}] Published successfully via captured ID (fallback): ${indicatorUrl}`)
+      return {
+        validation: validationResult,
+        publish: { success: true, indicatorUrl },
+      }
+    }
+
+    console.log('[TV Combined] Could not retrieve script URL after publish attempt')
+    return {
+      validation: validationResult,
+      publish: { success: false, error: 'Could not retrieve script URL after publish. The script may have been published - check your TradingView profile.' },
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    console.error(`[TV Combined:${reqId}] Infrastructure error (session/connection failure):`, errorMessage)
+    return {
+      validation: {
+        isValid: false,
+        errors: [
+          {
+            line: 0,
+            message: `Infrastructure error: ${errorMessage}. Please try again.`,
+            type: 'error',
+          },
+        ],
+        rawOutput: '',
+      },
+      infrastructureError: true,
+    }
+  } finally {
+    if (session) {
+      await closeBrowserSession(session)
+    }
+    releaseBrowserlessLock(reqId)
   }
 }

--- a/src/server/tradingview.ts
+++ b/src/server/tradingview.ts
@@ -2034,9 +2034,9 @@ export async function validateAndPublishWithWarmSession(
             return `attr:${sel}`
           }
         }
-        // Title attribute search (works better than CSS case-insensitive in headless Chrome)
-        const allClickable = Array.from(document.querySelectorAll('button, [role="button"], div, span, a'))
-        const titleMatch = allClickable.find(el => {
+        // Title attribute search - search ALL elements with title attribute
+        const allWithTitle = Array.from(document.querySelectorAll('[title]'))
+        const titleMatch = allWithTitle.find(el => {
           const title = el.getAttribute('title')?.toLowerCase() || ''
           return (title.includes('publish') || title.includes('share your script')) &&
                  el.getBoundingClientRect().width > 0

--- a/src/server/tradingview.ts
+++ b/src/server/tradingview.ts
@@ -2034,9 +2034,19 @@ export async function validateAndPublishWithWarmSession(
             return `attr:${sel}`
           }
         }
+        // Title attribute search (works better than CSS case-insensitive in headless Chrome)
+        const allClickable = Array.from(document.querySelectorAll('button, [role="button"], div, span, a'))
+        const titleMatch = allClickable.find(el => {
+          const title = el.getAttribute('title')?.toLowerCase() || ''
+          return (title.includes('publish') || title.includes('share your script')) &&
+                 el.getBoundingClientRect().width > 0
+        })
+        if (titleMatch) {
+          (titleMatch as HTMLElement).click()
+          return `title-js:${titleMatch.getAttribute('title')}`
+        }
         // Text-based search: find "Publish" in buttons/clickable elements
-        const allElements = Array.from(document.querySelectorAll('button, [role="button"], div, span, a'))
-        const publishEl = allElements.find(el => {
+        const publishEl = allClickable.find(el => {
           const text = el.textContent?.trim().toLowerCase() || ''
           return text.includes('publish') &&
                  el.getBoundingClientRect().width > 0 &&

--- a/src/server/tradingview.ts
+++ b/src/server/tradingview.ts
@@ -2026,8 +2026,8 @@ export async function validateAndPublishWithWarmSession(
             return `selector:${sel}`
           }
         }
-        // Try aria-label / title selectors
-        for (const sel of ['[aria-label*="Publish" i]', '[title*="Publish" i]', 'button[class*="publish" i]']) {
+        // Try aria-label / title selectors (including "Share your script" which is the current TradingView button title)
+        for (const sel of ['[aria-label*="Publish" i]', '[title*="Publish" i]', '[title*="Share your script" i]', 'button[class*="publish" i]']) {
           const btn = document.querySelector(sel) as HTMLElement
           if (btn && btn.getBoundingClientRect().width > 0) {
             btn.click()

--- a/src/server/tradingview.ts
+++ b/src/server/tradingview.ts
@@ -2046,6 +2046,7 @@ export async function validateAndPublishWithWarmSession(
           return `title-js:${titleMatch.getAttribute('title')}`
         }
         // Text-based search: find "Publish" in buttons/clickable elements
+        const allClickable = Array.from(document.querySelectorAll('button, [role="button"], div, span, a'))
         const publishEl = allClickable.find(el => {
           const text = el.textContent?.trim().toLowerCase() || ''
           return text.includes('publish') &&

--- a/src/server/validation-loop.ts
+++ b/src/server/validation-loop.ts
@@ -200,6 +200,7 @@ async function runValidationLoopInternal(
       }
     }
 
+    console.log(`[ValidationLoop:${requestId}] publishOptions from caller:`, JSON.stringify(publishOptions))
     const combinedResult = await validateAndPublishPineScript(credentials, currentScript, {
       title: publishOptions.title,
       description: publishOptions.description,

--- a/src/server/validation-loop.ts
+++ b/src/server/validation-loop.ts
@@ -9,6 +9,7 @@
  * 5. Return final result with indicator URL
  */
 
+import { randomUUID, createHash } from 'crypto'
 import { generateText } from 'ai'
 import { createOpenAI } from '@ai-sdk/openai'
 import {
@@ -22,8 +23,14 @@ import {
   buildFixPrompt,
   extractPineScript,
 } from './prompts/pine-script-fix'
-import { publishPineScript } from './tradingview'
+import { publishPineScript, validateAndPublishPineScript, validateAndPublishWithWarmSession } from './tradingview'
 import { startTimer } from './timing'
+import {
+  isWarmLocalBrowserEnabled,
+  acquireSession,
+  releaseSession,
+  getSessionStats,
+} from './warm-session'
 
 // OpenRouter client
 const openrouter = createOpenAI({
@@ -32,6 +39,15 @@ const openrouter = createOpenAI({
 })
 
 const DEFAULT_MODEL = process.env.OPENROUTER_MODEL || 'anthropic/claude-sonnet-4'
+
+// ============ Request Deduplication ============
+// Prevents duplicate requests from being processed (e.g., browser retry on timeout)
+const inFlightRequests = new Map<string, Promise<ValidationLoopResult>>()
+
+function getScriptHash(script: string): string {
+  // SHA-256 hash for reliable deduplication (prevents collisions)
+  return createHash('sha256').update(script).digest('hex')
+}
 
 /**
  * Options for publishing after validation
@@ -107,6 +123,34 @@ export async function runValidationLoop(
   maxRetries: number = 1,
   publishOptions?: PublishAfterValidationOptions
 ): Promise<ValidationLoopResult> {
+  const requestId = randomUUID().slice(0, 8)
+  const scriptHash = getScriptHash(script)
+
+  // Check for duplicate in-flight request
+  const existingRequest = inFlightRequests.get(scriptHash)
+  if (existingRequest) {
+    console.log(`[ValidationLoop:${requestId}] Duplicate request detected - returning existing result`)
+    return existingRequest
+  }
+
+  // Create and track the request promise
+  const requestPromise = runValidationLoopInternal(script, maxRetries, publishOptions, requestId)
+  inFlightRequests.set(scriptHash, requestPromise)
+
+  try {
+    return await requestPromise
+  } finally {
+    // Clean up after request completes
+    inFlightRequests.delete(scriptHash)
+  }
+}
+
+async function runValidationLoopInternal(
+  script: string,
+  maxRetries: number,
+  publishOptions: PublishAfterValidationOptions | undefined,
+  requestId: string
+): Promise<ValidationLoopResult> {
   const timer = startTimer('ValidationLoop', 'validation loop')
   let currentScript = script
   let iterations = 0
@@ -114,20 +158,129 @@ export async function runValidationLoop(
   let fixSuccessful = false
   let lastResult: FullValidationResult | null = null
 
-  console.log('[ValidationLoop] Starting validation loop...')
+  console.log(`[ValidationLoop:${requestId}] Starting validation loop...`)
 
-  // First validation attempt
-  iterations++
-  console.log(`[ValidationLoop] Iteration ${iterations}: Validating script...`)
-  lastResult = await validateWithServiceAccount(currentScript)
-  timer.mark('first validation')
+  // Check if warm local browser is enabled for fast validation
+  if (isWarmLocalBrowserEnabled()) {
+    console.log(`[ValidationLoop:${requestId}] Using warm local browser (USE_WARM_LOCAL_BROWSER=true)`)
+    const warmResult = await runValidationLoopWithWarmSession(
+      script,
+      maxRetries,
+      publishOptions,
+      timer,
+      requestId
+    )
+    return warmResult
+  }
 
-  if (lastResult.isValid) {
-    console.log('[ValidationLoop] Script is valid on first attempt')
+  // If publish options provided and no retries needed, use combined function (single browser session)
+  // This saves ~17s by reusing the browser session for both validation and publish
+  if (publishOptions && maxRetries === 1) {
+    console.log(`[ValidationLoop:${requestId}] Using combined validate+publish (single session optimization)`)
+    iterations++
+    console.log(`[ValidationLoop:${requestId}] Iteration ${iterations}: Validating script...`)
 
-    // If publish options provided, publish the script
-    if (publishOptions) {
-      const publishResult = await publishAfterValidation(currentScript, publishOptions, timer)
+    const credentials = await getServiceAccountCredentials()
+    if (!credentials) {
+      timer.end()
+      return {
+        finalScript: currentScript,
+        isValid: false,
+        iterations,
+        fixAttempted: false,
+        fixSuccessful: false,
+        finalErrors: [{
+          line: 0,
+          message: 'Service account authentication failed',
+          type: 'error',
+        }],
+        rawOutput: '',
+        addedToChart: false,
+        publishError: 'Service account authentication failed',
+      }
+    }
+
+    const combinedResult = await validateAndPublishPineScript(credentials, currentScript, {
+      title: publishOptions.title,
+      description: publishOptions.description,
+      visibility: publishOptions.visibility,
+    }, requestId)
+
+    timer.mark('combined validation + publish')
+
+    if (combinedResult.validation.isValid) {
+      console.log(`[ValidationLoop:${requestId}] Script is valid on first attempt`)
+      if (combinedResult.publish) {
+        timer.mark('publish complete')
+        console.log(`[ValidationLoop:${requestId}] Script published successfully: ${combinedResult.publish.indicatorUrl}`)
+      }
+      timer.end()
+      return {
+        finalScript: currentScript,
+        isValid: true,
+        iterations,
+        fixAttempted: false,
+        fixSuccessful: false,
+        finalErrors: [],
+        rawOutput: combinedResult.validation.rawOutput,
+        addedToChart: true,
+        indicatorUrl: combinedResult.publish?.indicatorUrl,
+        publishError: combinedResult.publish?.success === false ? combinedResult.publish.error : undefined,
+      }
+    }
+
+    // Check if this was an infrastructure error (session disconnect, etc.)
+    // If so, fail fast - don't retry with AI fix
+    if (combinedResult.infrastructureError) {
+      console.log(`[ValidationLoop:${requestId}] Infrastructure error - failing fast (no retry)`)
+      timer.end()
+      return {
+        finalScript: currentScript,
+        isValid: false,
+        iterations,
+        fixAttempted: false,
+        fixSuccessful: false,
+        finalErrors: combinedResult.validation.errors,
+        rawOutput: combinedResult.validation.rawOutput,
+        addedToChart: false,
+        publishError: 'Infrastructure error. Please try again.',
+      }
+    }
+
+    // Validation failed due to script errors - attempt AI fix
+    console.log(`[ValidationLoop:${requestId}] Validation failed due to script errors, attempting AI fix...`)
+    lastResult = {
+      ...combinedResult.validation,
+      addedToChart: false,
+    }
+  } else {
+    // Standard flow: validate first, then publish separately
+    iterations++
+    console.log(`[ValidationLoop:${requestId}] Iteration ${iterations}: Validating script...`)
+    lastResult = await validateWithServiceAccount(currentScript)
+    timer.mark('first validation')
+
+    if (lastResult.isValid) {
+      console.log(`[ValidationLoop:${requestId}] Script is valid on first attempt`)
+
+      // If publish options provided, publish the script
+      if (publishOptions) {
+        const publishResult = await publishAfterValidation(currentScript, publishOptions, timer)
+        return {
+          finalScript: currentScript,
+          isValid: true,
+          iterations,
+          fixAttempted: false,
+          fixSuccessful: false,
+          finalErrors: [],
+          rawOutput: lastResult.rawOutput,
+          addedToChart: lastResult.addedToChart,
+          indicatorUrl: publishResult.indicatorUrl,
+          publishError: publishResult.error,
+        }
+      }
+
+      timer.end()
       return {
         finalScript: currentScript,
         isValid: true,
@@ -137,27 +290,13 @@ export async function runValidationLoop(
         finalErrors: [],
         rawOutput: lastResult.rawOutput,
         addedToChart: lastResult.addedToChart,
-        indicatorUrl: publishResult.indicatorUrl,
-        publishError: publishResult.error,
       }
-    }
-
-    timer.end()
-    return {
-      finalScript: currentScript,
-      isValid: true,
-      iterations,
-      fixAttempted: false,
-      fixSuccessful: false,
-      finalErrors: [],
-      rawOutput: lastResult.rawOutput,
-      addedToChart: lastResult.addedToChart,
     }
   }
 
   // Script has errors - attempt AI fix if retries available
   if (maxRetries > 0) {
-    console.log('[ValidationLoop] Script has errors, attempting AI fix...')
+    console.log(`[ValidationLoop:${requestId}] Script has errors, attempting AI fix...`)
     fixAttempted = true
 
     try {
@@ -166,17 +305,17 @@ export async function runValidationLoop(
 
       // Sanity check: ensure we got a non-empty response
       if (!fixedScript || fixedScript.length < 10) {
-        console.log('[ValidationLoop] AI fix returned empty or invalid script')
+        console.log(`[ValidationLoop:${requestId}] AI fix returned empty or invalid script`)
       } else {
         currentScript = fixedScript
 
         // Re-validate with fixed script
         iterations++
-        console.log(`[ValidationLoop] Iteration ${iterations}: Re-validating fixed script...`)
+        console.log(`[ValidationLoop:${requestId}] Iteration ${iterations}: Re-validating fixed script...`)
         lastResult = await validateWithServiceAccount(currentScript)
 
         if (lastResult.isValid) {
-          console.log('[ValidationLoop] AI fix successful - script is now valid')
+          console.log(`[ValidationLoop:${requestId}] AI fix successful - script is now valid`)
           fixSuccessful = true
           timer.mark('AI fix successful')
 
@@ -209,17 +348,17 @@ export async function runValidationLoop(
             addedToChart: lastResult.addedToChart,
           }
         } else {
-          console.log('[ValidationLoop] AI fix applied but script still has errors')
+          console.log(`[ValidationLoop:${requestId}] AI fix applied but script still has errors`)
         }
       }
     } catch (error) {
-      console.error('[ValidationLoop] AI fix failed:', error)
+      console.error(`[ValidationLoop:${requestId}] AI fix failed:`, error)
       // Continue with original script's errors
     }
   }
 
   // Return final result (script is still invalid)
-  console.log(`[ValidationLoop] Validation complete after ${iterations} iterations - script is invalid`)
+  console.log(`[ValidationLoop:${requestId}] Validation complete after ${iterations} iterations - script is invalid`)
   timer.end()
   return {
     finalScript: currentScript,
@@ -230,6 +369,225 @@ export async function runValidationLoop(
     finalErrors: lastResult?.errors || [],
     rawOutput: lastResult?.rawOutput || '',
     addedToChart: lastResult?.addedToChart || false,
+  }
+}
+
+/**
+ * Run validation loop using warm local browser session
+ * This is the fast path (~8s) vs Browserless (~70s)
+ */
+async function runValidationLoopWithWarmSession(
+  script: string,
+  maxRetries: number,
+  publishOptions: PublishAfterValidationOptions | undefined,
+  timer: ReturnType<typeof startTimer>,
+  requestId: string
+): Promise<ValidationLoopResult> {
+  let currentScript = script
+  let iterations = 0
+  let fixAttempted = false
+  let fixSuccessful = false
+  let lastResult: FullValidationResult | null = null
+
+  // Get service account credentials
+  const credentials = await getServiceAccountCredentials()
+  if (!credentials) {
+    timer.end()
+    return {
+      finalScript: currentScript,
+      isValid: false,
+      iterations: 0,
+      fixAttempted: false,
+      fixSuccessful: false,
+      finalErrors: [{
+        line: 0,
+        message: 'Service account authentication failed',
+        type: 'error',
+      }],
+      rawOutput: '',
+      addedToChart: false,
+      publishError: 'Service account authentication failed',
+    }
+  }
+
+  // Acquire warm session
+  let sessionAcquired = false
+  try {
+    console.log(`[ValidationLoop/Warm:${requestId}] Acquiring warm session...`)
+    const stats = getSessionStats()
+    console.log(`[ValidationLoop/Warm:${requestId}] Session stats: ${JSON.stringify(stats)}`)
+
+    const session = await acquireSession(credentials)
+    sessionAcquired = true
+    timer.mark('warm session acquired')
+
+    // First validation attempt
+    iterations++
+    console.log(`[ValidationLoop/Warm:${requestId}] Iteration ${iterations}: Validating script...`)
+
+    const combinedResult = await validateAndPublishWithWarmSession(
+      session.page,
+      currentScript,
+      publishOptions ? {
+        title: publishOptions.title,
+        description: publishOptions.description,
+        visibility: publishOptions.visibility,
+      } : undefined
+    )
+
+    timer.mark('warm validation complete')
+
+    if (combinedResult.validation.isValid) {
+      console.log(`[ValidationLoop/Warm:${requestId}] Script is valid on first attempt`)
+
+      // Release session with success
+      await releaseSession(true)
+      sessionAcquired = false
+
+      if (combinedResult.publish) {
+        timer.mark('publish complete')
+        console.log(`[ValidationLoop/Warm:${requestId}] Script published: ${combinedResult.publish.indicatorUrl}`)
+      }
+
+      timer.end()
+      return {
+        finalScript: currentScript,
+        isValid: true,
+        iterations,
+        fixAttempted: false,
+        fixSuccessful: false,
+        finalErrors: [],
+        rawOutput: combinedResult.validation.rawOutput,
+        addedToChart: true,
+        indicatorUrl: combinedResult.publish?.indicatorUrl,
+        publishError: combinedResult.publish?.success === false ? combinedResult.publish.error : undefined,
+      }
+    }
+
+    // Validation failed - store result for AI fix attempt
+    lastResult = {
+      ...combinedResult.validation,
+      addedToChart: false,
+    }
+
+    // Release session before AI fix (don't block other requests)
+    await releaseSession(true)
+    sessionAcquired = false
+
+    // Attempt AI fix if retries available
+    if (maxRetries > 0) {
+      console.log(`[ValidationLoop/Warm:${requestId}] Script has errors, attempting AI fix...`)
+      fixAttempted = true
+
+      try {
+        const errorString = formatErrorsForLLM(lastResult)
+        const fixedScript = await fixPineScriptErrors(currentScript, errorString)
+
+        if (!fixedScript || fixedScript.length < 10) {
+          console.log(`[ValidationLoop/Warm:${requestId}] AI fix returned empty or invalid script`)
+        } else {
+          currentScript = fixedScript
+          timer.mark('AI fix generated')
+
+          // Re-acquire session for second validation
+          console.log(`[ValidationLoop/Warm:${requestId}] Re-acquiring warm session for fixed script...`)
+          const retrySession = await acquireSession(credentials)
+          sessionAcquired = true
+
+          // Re-validate fixed script
+          iterations++
+          console.log(`[ValidationLoop/Warm:${requestId}] Iteration ${iterations}: Re-validating fixed script...`)
+
+          const retryResult = await validateAndPublishWithWarmSession(
+            retrySession.page,
+            currentScript,
+            publishOptions ? {
+              title: publishOptions.title,
+              description: publishOptions.description,
+              visibility: publishOptions.visibility,
+            } : undefined
+          )
+
+          await releaseSession(true)
+          sessionAcquired = false
+
+          if (retryResult.validation.isValid) {
+            console.log(`[ValidationLoop/Warm:${requestId}] AI fix successful - script is now valid`)
+            fixSuccessful = true
+            timer.mark('AI fix successful')
+
+            if (retryResult.publish) {
+              timer.mark('publish complete')
+              console.log(`[ValidationLoop/Warm:${requestId}] Script published: ${retryResult.publish.indicatorUrl}`)
+            }
+
+            timer.end()
+            return {
+              finalScript: currentScript,
+              isValid: true,
+              iterations,
+              fixAttempted: true,
+              fixSuccessful: true,
+              finalErrors: [],
+              rawOutput: retryResult.validation.rawOutput,
+              addedToChart: true,
+              indicatorUrl: retryResult.publish?.indicatorUrl,
+              publishError: retryResult.publish?.success === false ? retryResult.publish.error : undefined,
+            }
+          } else {
+            console.log(`[ValidationLoop/Warm:${requestId}] AI fix applied but script still has errors`)
+            lastResult = {
+              ...retryResult.validation,
+              addedToChart: false,
+            }
+          }
+        }
+      } catch (error) {
+        console.error(`[ValidationLoop/Warm:${requestId}] AI fix failed:`, error)
+        // Release session if acquired during AI fix retry to prevent deadlock
+        if (sessionAcquired) {
+          await releaseSession(false)
+          sessionAcquired = false
+        }
+      }
+    }
+
+    // Return final result (script is still invalid)
+    console.log(`[ValidationLoop/Warm:${requestId}] Validation complete after ${iterations} iterations - script is invalid`)
+    timer.end()
+    return {
+      finalScript: currentScript,
+      isValid: false,
+      iterations,
+      fixAttempted,
+      fixSuccessful,
+      finalErrors: lastResult?.errors || [],
+      rawOutput: lastResult?.rawOutput || '',
+      addedToChart: lastResult?.addedToChart || false,
+    }
+  } catch (error) {
+    console.error(`[ValidationLoop/Warm:${requestId}] Error:`, error)
+
+    // Release session on error
+    if (sessionAcquired) {
+      await releaseSession(false)
+    }
+
+    timer.end()
+    return {
+      finalScript: currentScript,
+      isValid: false,
+      iterations,
+      fixAttempted,
+      fixSuccessful,
+      finalErrors: [{
+        line: 0,
+        message: `Warm session validation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        type: 'error',
+      }],
+      rawOutput: '',
+      addedToChart: false,
+    }
   }
 }
 

--- a/src/server/validation-loop.ts
+++ b/src/server/validation-loop.ts
@@ -170,14 +170,21 @@ async function runValidationLoopInternal(
   // Check if warm local browser is enabled for fast validation
   if (isWarmLocalBrowserEnabled()) {
     console.log(`[ValidationLoop:${requestId}] Using warm local browser (USE_WARM_LOCAL_BROWSER=true)`)
-    const warmResult = await runValidationLoopWithWarmSession(
-      script,
-      maxRetries,
-      publishOptions,
-      timer,
-      requestId
-    )
-    return warmResult
+    try {
+      const warmResult = await runValidationLoopWithWarmSession(
+        script,
+        maxRetries,
+        publishOptions,
+        timer,
+        requestId
+      )
+      return warmResult
+    } catch (error) {
+      console.error(
+        `[ValidationLoop:${requestId}] Warm local browser path failed, falling back to regular path:`,
+        error
+      )
+    }
   }
 
   // If publish options provided, use shared code path (single browser session for validate + publish)

--- a/src/server/warm-session.ts
+++ b/src/server/warm-session.ts
@@ -10,7 +10,7 @@
 import puppeteer, { Browser, Page } from 'puppeteer-core'
 import fs from 'fs'
 import { injectCookies } from './browserless'
-import { parseTVCookies, TV_SELECTORS, type TVCredentials } from './tradingview'
+import { parseTVCookies, TV_SELECTORS, SCREENSHOT_DIR, type TVCredentials } from './tradingview'
 
 // Environment configuration
 const USE_WARM_LOCAL_BROWSER = process.env.USE_WARM_LOCAL_BROWSER === 'true'
@@ -175,8 +175,8 @@ async function createWarmSession(credentials: TVCredentials): Promise<WarmSessio
     console.log('[Warm Session] WARNING: May not be logged in to TradingView')
     // Take screenshot for debugging
     try {
-      await page.screenshot({ path: '/tmp/warm-session-not-logged-in.png' })
-      console.log('[Warm Session] Screenshot saved to /tmp/warm-session-not-logged-in.png')
+      await page.screenshot({ path: `${SCREENSHOT_DIR}/warm-session-not-logged-in.png` })
+      console.log(`[Warm Session] Screenshot saved to ${SCREENSHOT_DIR}/warm-session-not-logged-in.png`)
     } catch (e) {
       console.log('[Warm Session] Could not take screenshot')
     }
@@ -265,8 +265,8 @@ async function createWarmSession(credentials: TVCredentials): Promise<WarmSessio
   if (!editorFound) {
     // Take screenshot for debugging
     try {
-      await page.screenshot({ path: '/tmp/warm-session-editor-not-found.png' })
-      console.log('[Warm Session] Screenshot saved to /tmp/warm-session-editor-not-found.png')
+      await page.screenshot({ path: `${SCREENSHOT_DIR}/warm-session-editor-not-found.png` })
+      console.log(`[Warm Session] Screenshot saved to ${SCREENSHOT_DIR}/warm-session-editor-not-found.png`)
     } catch (e) {
       console.log('[Warm Session] Could not take screenshot:', e)
     }

--- a/src/server/warm-session.ts
+++ b/src/server/warm-session.ts
@@ -1,0 +1,653 @@
+/**
+ * Warm Session Manager
+ *
+ * Manages a persistent browser session with TradingView pre-loaded for fast validation.
+ * Session stays warm between requests to avoid cold start latency (~70s -> ~8s).
+ *
+ * Feature flag: USE_WARM_LOCAL_BROWSER=true enables this path
+ */
+
+import puppeteer, { Browser, Page } from 'puppeteer-core'
+import fs from 'fs'
+import { injectCookies } from './browserless'
+import { parseTVCookies, TV_SELECTORS, type TVCredentials } from './tradingview'
+
+// Environment configuration
+const USE_WARM_LOCAL_BROWSER = process.env.USE_WARM_LOCAL_BROWSER === 'true'
+const PUPPETEER_EXECUTABLE_PATH = process.env.PUPPETEER_EXECUTABLE_PATH
+
+// Warm session configuration (configurable via env)
+const IDLE_TIMEOUT = parseInt(process.env.WARM_SESSION_IDLE_TIMEOUT || '1800000') // 30 min default
+const MAX_AGE = parseInt(process.env.WARM_SESSION_MAX_AGE || '7200000') // 2 hours default
+const MAX_REQUESTS = parseInt(process.env.WARM_SESSION_MAX_REQUESTS || '500') // 500 requests default
+const ACQUIRE_TIMEOUT = 30000 // 30 seconds to wait for busy session
+
+export interface WarmSession {
+  browser: Browser
+  page: Page
+  state: 'idle' | 'busy' | 'error'
+  createdAt: number
+  lastUsedAt: number
+  requestsServed: number
+}
+
+// Singleton warm session
+let warmSession: WarmSession | null = null
+let idleTimer: NodeJS.Timeout | null = null
+let acquireQueue: Array<{
+  resolve: (session: WarmSession) => void
+  reject: (error: Error) => void
+}> = []
+
+// Lock to prevent race condition when creating session
+let sessionCreationPromise: Promise<WarmSession> | null = null
+
+/**
+ * Check if warm local browser is enabled
+ */
+export function isWarmLocalBrowserEnabled(): boolean {
+  return USE_WARM_LOCAL_BROWSER
+}
+
+/**
+ * Get Chrome executable path
+ */
+function getChromePath(): string {
+  // Production: Use Dockerfile-configured path
+  if (PUPPETEER_EXECUTABLE_PATH) {
+    if (fs.existsSync(PUPPETEER_EXECUTABLE_PATH)) {
+      return PUPPETEER_EXECUTABLE_PATH
+    }
+    throw new Error(`PUPPETEER_EXECUTABLE_PATH set to ${PUPPETEER_EXECUTABLE_PATH} but file does not exist`)
+  }
+
+  // Development: Auto-detect Chrome
+  const paths: Record<string, string[]> = {
+    linux: [
+      '/usr/bin/google-chrome',
+      '/usr/bin/google-chrome-stable',
+      '/usr/bin/chromium-browser',
+      '/usr/bin/chromium',
+    ],
+    darwin: [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    ],
+    win32: [
+      'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+      'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    ],
+  }
+
+  const osPaths = paths[process.platform] || []
+  for (const p of osPaths) {
+    if (fs.existsSync(p)) {
+      return p
+    }
+  }
+
+  throw new Error(`Chrome not found. Set PUPPETEER_EXECUTABLE_PATH env var. Searched: ${osPaths.join(', ')}`)
+}
+
+/**
+ * Reset idle timer - called when session is released back to pool
+ */
+function resetIdleTimer(): void {
+  if (idleTimer) {
+    clearTimeout(idleTimer)
+  }
+
+  idleTimer = setTimeout(async () => {
+    console.log(`[Warm Session] Idle timeout reached (${IDLE_TIMEOUT}ms), closing browser...`)
+    await shutdownSession()
+  }, IDLE_TIMEOUT)
+}
+
+/**
+ * Create a new warm session with TradingView + Pine Editor pre-loaded
+ */
+async function createWarmSession(credentials: TVCredentials): Promise<WarmSession> {
+  console.log('[Warm Session] Creating new warm session...')
+  const startTime = Date.now()
+
+  const chromePath = getChromePath()
+  console.log(`[Warm Session] Launching Chrome: ${chromePath}`)
+
+  const args = [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-dev-shm-usage',
+    '--disable-gpu',
+    '--disable-software-rasterizer',
+    '--disable-extensions',
+    '--disable-background-networking',
+    '--disable-default-apps',
+    '--disable-sync',
+    '--no-first-run',
+    '--disable-accelerated-2d-canvas',
+    '--disable-canvas-aa',
+    '--disable-2d-canvas-clip-aa',
+    '--disable-gl-drawing-for-tests',
+  ]
+
+  const browser = await puppeteer.launch({
+    headless: true,
+    executablePath: chromePath,
+    args,
+    defaultViewport: { width: 1920, height: 1080 },
+  })
+
+  const page = await browser.newPage()
+
+  // Auto-accept all dialogs
+  page.on('dialog', async (dialog) => {
+    console.log(`[Warm Session] Auto-accepting dialog: ${dialog.type()} - "${dialog.message()}"`)
+    await dialog.accept()
+  })
+
+  // Set realistic user agent
+  await page.setUserAgent(
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+  )
+
+  // Inject credentials
+  const cookies = parseTVCookies(credentials)
+  await injectCookies(page, cookies)
+  console.log('[Warm Session] Credentials injected')
+
+  // Navigate to TradingView chart page
+  console.log('[Warm Session] Navigating to TradingView...')
+  await page.goto('https://www.tradingview.com/chart/', {
+    waitUntil: 'networkidle2',
+    timeout: 60000,
+  })
+
+  // Wait for page to stabilize and check if we're logged in
+  await delay(3000)
+
+  // Check if we're logged in using same selector as browserless implementation
+  const isLoggedIn = await page.evaluate((selector) => {
+    const userMenu = document.querySelector(selector)
+    return !!userMenu
+  }, TV_SELECTORS.auth.userMenu)
+
+  if (!isLoggedIn) {
+    console.log('[Warm Session] WARNING: May not be logged in to TradingView')
+    // Take screenshot for debugging
+    try {
+      await page.screenshot({ path: '/tmp/warm-session-not-logged-in.png' })
+      console.log('[Warm Session] Screenshot saved to /tmp/warm-session-not-logged-in.png')
+    } catch (e) {
+      console.log('[Warm Session] Could not take screenshot')
+    }
+  } else {
+    console.log('[Warm Session] Confirmed logged in to TradingView')
+  }
+
+  // Open Pine Editor - same logic as browserless implementation
+  console.log('[Warm Session] Opening Pine Editor...')
+
+  // First check if Pine Editor is already open
+  const pineEditorVisible = await page.$(TV_SELECTORS.pineEditor.container)
+  if (pineEditorVisible) {
+    console.log('[Warm Session] Pine Editor already open')
+  } else {
+    // Try to click the Pine Editor button
+    const editorButtonSelectors = [
+      TV_SELECTORS.chart.pineEditorButton,  // '[data-name="open-pine-editor"]'
+      'button[title="Pine"]',
+      'button[aria-label="Pine"]',
+      'button[title*="Pine"]',
+      'button[aria-label*="Pine"]',
+    ]
+
+    let buttonFound = false
+    for (const selector of editorButtonSelectors) {
+      try {
+        const button = await page.$(selector)
+        if (button) {
+          await button.click()
+          buttonFound = true
+          console.log(`[Warm Session] Clicked Pine Editor button: ${selector}`)
+          break
+        }
+      } catch {
+        // Try next
+      }
+    }
+
+    if (!buttonFound) {
+      // Try finding by title/aria-label (same as browserless implementation)
+      const clicked = await page.evaluate(() => {
+        const buttons = Array.from(document.querySelectorAll('button, div[role="button"], [role="button"]'))
+        const pineBtn = buttons.find(btn => {
+          const title = btn.getAttribute('title')
+          const ariaLabel = btn.getAttribute('aria-label')
+          return (title && title.toLowerCase().includes('pine')) ||
+                 (ariaLabel && ariaLabel.toLowerCase().includes('pine'))
+        })
+        if (pineBtn) {
+          (pineBtn as HTMLElement).click()
+          return true
+        }
+        return false
+      })
+
+      if (clicked) {
+        buttonFound = true
+        console.log('[Warm Session] Clicked Pine button via text search')
+      }
+    }
+  }
+
+  // Wait for Pine Editor container and Monaco editor - same selectors as browserless
+  console.log('[Warm Session] Waiting for Pine Editor to load...')
+  const pineEditorSelectors = [
+    TV_SELECTORS.pineEditor.container,  // '[data-name="pine-editor"]'
+    '.pine-editor-container',
+    '[data-role="panel-Pine"]',
+    '[id*="pine"]',
+    TV_SELECTORS.pineEditor.editorArea, // '.monaco-editor'
+  ]
+
+  let editorFound = false
+  for (const selector of pineEditorSelectors) {
+    try {
+      await page.waitForSelector(selector, { timeout: 10000 })
+      console.log(`[Warm Session] Found editor with selector: ${selector}`)
+      editorFound = true
+      break
+    } catch {
+      console.log(`[Warm Session] Selector ${selector} not found, trying next...`)
+    }
+  }
+
+  if (!editorFound) {
+    // Take screenshot for debugging
+    try {
+      await page.screenshot({ path: '/tmp/warm-session-editor-not-found.png' })
+      console.log('[Warm Session] Screenshot saved to /tmp/warm-session-editor-not-found.png')
+    } catch (e) {
+      console.log('[Warm Session] Could not take screenshot:', e)
+    }
+
+    // Check current URL - might have been redirected to login
+    const currentUrl = page.url()
+    console.log(`[Warm Session] Current URL: ${currentUrl}`)
+
+    // Check for login page indicators
+    const isLoginPage = await page.evaluate(() => {
+      const url = window.location.href
+      const hasLoginForm = !!document.querySelector('input[type="password"]')
+      return url.includes('signin') || url.includes('login') || hasLoginForm
+    })
+
+    if (isLoginPage) {
+      throw new Error('TradingView session expired - redirected to login page. Please refresh credentials.')
+    }
+
+    throw new Error('Monaco editor did not load - Pine Editor panel may not have opened')
+  }
+
+  await delay(500)
+
+  // Remove any existing indicators from the chart (TradingView free tier limits to 2)
+  console.log('[Warm Session] Cleaning up existing indicators...')
+  const removedCount = await page.evaluate(() => {
+    let removed = 0
+    // Find all indicator close/remove buttons
+    const removeButtons = document.querySelectorAll(
+      '[data-name="legend-delete-action"], ' +
+      '[class*="legend-"] button[aria-label*="Remove" i], ' +
+      '[class*="legend-"] button[aria-label*="Delete" i], ' +
+      '[class*="legend-"] [class*="close"], ' +
+      '[class*="legend-"] [class*="remove"]'
+    )
+    for (const btn of removeButtons) {
+      try {
+        (btn as HTMLElement).click()
+        removed++
+      } catch {
+        // Ignore
+      }
+    }
+    return removed
+  })
+
+  if (removedCount > 0) {
+    console.log(`[Warm Session] Removed ${removedCount} existing indicators`)
+    await delay(500)
+  } else {
+    console.log('[Warm Session] No existing indicators to remove')
+  }
+
+  const session: WarmSession = {
+    browser,
+    page,
+    state: 'idle',
+    createdAt: Date.now(),
+    lastUsedAt: Date.now(),
+    requestsServed: 0,
+  }
+
+  const elapsed = Date.now() - startTime
+  console.log(`[Warm Session] Session created in ${elapsed}ms`)
+
+  return session
+}
+
+/**
+ * Check if session needs to be refreshed (age or request count limits)
+ */
+function sessionNeedsRefresh(session: WarmSession): boolean {
+  const age = Date.now() - session.createdAt
+  if (age > MAX_AGE) {
+    console.log(`[Warm Session] Session exceeded max age (${age}ms > ${MAX_AGE}ms)`)
+    return true
+  }
+  if (session.requestsServed >= MAX_REQUESTS) {
+    console.log(`[Warm Session] Session exceeded max requests (${session.requestsServed} >= ${MAX_REQUESTS})`)
+    return true
+  }
+  return false
+}
+
+/**
+ * Acquire a warm session for use
+ * - Creates a new session if none exists
+ * - Waits if session is busy
+ * - Refreshes session if needed
+ */
+export async function acquireSession(credentials: TVCredentials): Promise<WarmSession> {
+  const startTime = Date.now()
+
+  // If no session exists, create one (with lock to prevent race condition)
+  if (!warmSession) {
+    // Check if another request is already creating a session
+    if (sessionCreationPromise) {
+      console.log('[Warm Session] Session creation in progress, waiting...')
+      await sessionCreationPromise
+      // After waiting, the session should exist - recursively try to acquire
+      return acquireSession(credentials)
+    }
+
+    console.log('[Warm Session] No warm session exists, creating...')
+
+    // Set the lock before starting creation
+    sessionCreationPromise = createWarmSession(credentials)
+
+    try {
+      warmSession = await sessionCreationPromise
+      warmSession.state = 'busy'
+      warmSession.lastUsedAt = Date.now()
+      warmSession.requestsServed++
+      resetIdleTimer()
+      console.log(`[Warm Session] Acquired (cold start) in ${Date.now() - startTime}ms`)
+      return warmSession
+    } finally {
+      // Clear the lock
+      sessionCreationPromise = null
+    }
+  }
+
+  // If session exists but needs refresh
+  if (sessionNeedsRefresh(warmSession)) {
+    console.log('[Warm Session] Refreshing session due to limits...')
+    await shutdownSession()
+    warmSession = await createWarmSession(credentials)
+    warmSession.state = 'busy'
+    warmSession.lastUsedAt = Date.now()
+    warmSession.requestsServed++
+    resetIdleTimer()
+    console.log(`[Warm Session] Acquired (refreshed) in ${Date.now() - startTime}ms`)
+    return warmSession
+  }
+
+  // If session is idle, acquire it
+  if (warmSession.state === 'idle') {
+    warmSession.state = 'busy'
+    warmSession.lastUsedAt = Date.now()
+    warmSession.requestsServed++
+
+    // Clear idle timer while session is in use
+    if (idleTimer) {
+      clearTimeout(idleTimer)
+      idleTimer = null
+    }
+
+    console.log(`[Warm Session] Acquired (warm) in ${Date.now() - startTime}ms`)
+    return warmSession
+  }
+
+  // If session is busy, wait in queue
+  if (warmSession.state === 'busy') {
+    console.log('[Warm Session] Session busy, waiting in queue...')
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        // Remove from queue
+        acquireQueue = acquireQueue.filter(item => item.resolve !== resolve)
+        reject(new Error(`Timeout waiting for warm session (${ACQUIRE_TIMEOUT}ms)`))
+      }, ACQUIRE_TIMEOUT)
+
+      acquireQueue.push({
+        resolve: (session: WarmSession) => {
+          clearTimeout(timeout)
+          session.lastUsedAt = Date.now()
+          session.requestsServed++
+          console.log(`[Warm Session] Acquired (from queue) in ${Date.now() - startTime}ms`)
+          resolve(session)
+        },
+        reject: (error: Error) => {
+          clearTimeout(timeout)
+          reject(error)
+        },
+      })
+    })
+  }
+
+  // Session is in error state, recreate
+  console.log('[Warm Session] Session in error state, recreating...')
+  await shutdownSession()
+  warmSession = await createWarmSession(credentials)
+  warmSession.state = 'busy'
+  warmSession.lastUsedAt = Date.now()
+  warmSession.requestsServed++
+  resetIdleTimer()
+  console.log(`[Warm Session] Acquired (recovered from error) in ${Date.now() - startTime}ms`)
+  return warmSession
+}
+
+/**
+ * Release session back to pool after use
+ */
+export async function releaseSession(success: boolean): Promise<void> {
+  if (!warmSession) {
+    console.log('[Warm Session] No session to release')
+    return
+  }
+
+  if (success) {
+    warmSession.state = 'idle'
+    console.log(`[Warm Session] Released (${warmSession.requestsServed} requests served)`)
+
+    // Process waiting queue
+    if (acquireQueue.length > 0) {
+      const next = acquireQueue.shift()!
+      warmSession.state = 'busy'
+      next.resolve(warmSession)
+      return
+    }
+
+    // Start idle timer
+    resetIdleTimer()
+  } else {
+    // Mark as error - will be recreated on next acquire
+    warmSession.state = 'error'
+    console.log('[Warm Session] Released with error, will recreate on next acquire')
+
+    // Reject all waiting requests
+    for (const waiter of acquireQueue) {
+      waiter.reject(new Error('Session failed, please retry'))
+    }
+    acquireQueue = []
+  }
+}
+
+/**
+ * Reset editor state between requests
+ * Clears editor content and dismisses any dialogs
+ */
+export async function resetEditorState(page: Page): Promise<void> {
+  console.log('[Warm Session] Resetting editor state...')
+
+  // Dismiss any open dialogs
+  await page.keyboard.press('Escape')
+  await delay(100)
+  await page.keyboard.press('Escape')
+  await delay(100)
+
+  // Check if Monaco editor is accessible
+  const editorExists = await page.$('.monaco-editor')
+
+  if (!editorExists) {
+    console.log('[Warm Session] Monaco editor not found, navigating back to chart...')
+    const currentUrl = page.url()
+    console.log(`[Warm Session] Current URL: ${currentUrl}`)
+
+    // Navigate back to chart page
+    await page.goto('https://www.tradingview.com/chart/', {
+      waitUntil: 'networkidle2',
+      timeout: 30000,
+    })
+    await delay(2000)
+
+    // Reopen Pine Editor
+    const editorButtonSelectors = [
+      TV_SELECTORS.chart.pineEditorButton,
+      'button[title="Pine"]',
+      'button[aria-label="Pine"]',
+    ]
+
+    for (const selector of editorButtonSelectors) {
+      try {
+        const button = await page.$(selector)
+        if (button) {
+          await button.click()
+          console.log(`[Warm Session] Clicked Pine Editor button: ${selector}`)
+          break
+        }
+      } catch {
+        // Try next
+      }
+    }
+
+    // Wait for editor to load
+    await page.waitForSelector('.monaco-editor', { timeout: 10000 })
+    await delay(500)
+    console.log('[Warm Session] Pine Editor reopened')
+  }
+
+  // Click on Monaco editor to focus
+  try {
+    await page.click('.monaco-editor')
+    await delay(100)
+
+    // Select all and delete
+    await page.keyboard.down('Control')
+    await page.keyboard.press('a')
+    await page.keyboard.up('Control')
+    await delay(50)
+    await page.keyboard.press('Delete')
+    await delay(100)
+  } catch (error) {
+    console.log('[Warm Session] Error resetting editor:', error)
+    throw error // Re-throw to trigger session refresh
+  }
+
+  console.log('[Warm Session] Editor state reset complete')
+}
+
+/**
+ * Check if session is healthy (browser connected, page responsive)
+ */
+export async function checkSessionHealth(): Promise<boolean> {
+  if (!warmSession) return false
+
+  try {
+    // Check if browser is still connected
+    if (!warmSession.browser.isConnected()) {
+      console.log('[Warm Session] Health check failed: browser disconnected')
+      return false
+    }
+
+    // Check if page is responsive
+    await warmSession.page.evaluate(() => true)
+    return true
+  } catch (error) {
+    console.log('[Warm Session] Health check failed:', error)
+    return false
+  }
+}
+
+/**
+ * Shutdown warm session (for graceful server stop or idle timeout)
+ */
+export async function shutdownSession(): Promise<void> {
+  if (idleTimer) {
+    clearTimeout(idleTimer)
+    idleTimer = null
+  }
+
+  // Clear creation lock if it exists
+  sessionCreationPromise = null
+
+  if (!warmSession) {
+    console.log('[Warm Session] No session to shutdown')
+    return
+  }
+
+  try {
+    console.log('[Warm Session] Shutting down...')
+    await warmSession.browser.close()
+    console.log('[Warm Session] Browser closed')
+  } catch (error) {
+    console.error('[Warm Session] Error closing browser:', error)
+  }
+
+  // Reject all waiting requests
+  for (const waiter of acquireQueue) {
+    waiter.reject(new Error('Session shutdown'))
+  }
+  acquireQueue = []
+
+  warmSession = null
+}
+
+/**
+ * Get warm session stats (for monitoring/debugging)
+ */
+export function getSessionStats(): {
+  hasSession: boolean
+  state?: string
+  requestsServed?: number
+  ageMs?: number
+  idleSinceMs?: number
+  queueLength: number
+} {
+  if (!warmSession) {
+    return { hasSession: false, queueLength: acquireQueue.length }
+  }
+
+  return {
+    hasSession: true,
+    state: warmSession.state,
+    requestsServed: warmSession.requestsServed,
+    ageMs: Date.now() - warmSession.createdAt,
+    idleSinceMs: warmSession.state === 'idle' ? Date.now() - warmSession.lastUsedAt : undefined,
+    queueLength: acquireQueue.length,
+  }
+}
+
+// Helper
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))

--- a/src/server/warm-session.ts
+++ b/src/server/warm-session.ts
@@ -4,7 +4,8 @@
  * Manages a persistent browser session with TradingView pre-loaded for fast validation.
  * Session stays warm between requests to avoid cold start latency (~70s -> ~8s).
  *
- * Feature flag: USE_WARM_LOCAL_BROWSER=true enables this path
+ * Feature flag: USE_WARM_LOCAL_BROWSER=true enables this path.
+ * Production default is enabled unless explicitly set to false.
  */
 
 import puppeteer, { Browser, Page } from 'puppeteer-core'
@@ -20,7 +21,6 @@ import {
 } from './tradingview'
 
 // Environment configuration
-const USE_WARM_LOCAL_BROWSER = process.env.USE_WARM_LOCAL_BROWSER === 'true'
 const PUPPETEER_EXECUTABLE_PATH = process.env.PUPPETEER_EXECUTABLE_PATH
 
 // Helper for retrying operations with exponential backoff
@@ -83,7 +83,10 @@ let preWarmCredentials: TVCredentials | null = null
  * Check if warm local browser is enabled
  */
 export function isWarmLocalBrowserEnabled(): boolean {
-  return USE_WARM_LOCAL_BROWSER
+  const raw = process.env.USE_WARM_LOCAL_BROWSER
+  if (raw === 'true') return true
+  if (raw === 'false') return false
+  return process.env.NODE_ENV === 'production'
 }
 
 /**

--- a/tests/tradingview-url-capture.test.ts
+++ b/tests/tradingview-url-capture.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canonicalizeTradingViewScriptUrl,
+  extractScriptIdFromText,
+  extractScriptIdFromUrl,
+  resolveScriptsApiUsername,
+  selectExactTitleMatchScriptUrl,
+} from '../src/server/tradingview'
+
+describe('tradingview URL capture helpers', () => {
+  it('canonicalizes full script URLs to canonical form', () => {
+    const result = canonicalizeTradingViewScriptUrl('https://www.tradingview.com/script/AbC123/My-Indicator/?foo=bar')
+    expect(result).toBe('https://www.tradingview.com/script/AbC123/')
+  })
+
+  it('extracts script id from JSON payload text', () => {
+    const result = extractScriptIdFromText('{"scriptId":"XyZ789"}')
+    expect(result).toBe('XyZ789')
+  })
+
+  it('extracts script id from URL', () => {
+    const result = extractScriptIdFromUrl('https://www.tradingview.com/script/LMN456/')
+    expect(result).toBe('LMN456')
+  })
+
+  it('selects exact title match only from scripts API results', () => {
+    const result = selectExactTitleMatchScriptUrl('My Exact Script', [
+      { name: 'My Exact Script', chart_url: 'https://www.tradingview.com/script/AbC111/' },
+      { name: 'My Exact Script Copy', chart_url: 'https://www.tradingview.com/script/Bad999/' },
+    ])
+    expect(result).toBe('https://www.tradingview.com/script/AbC111/')
+  })
+
+  it('rejects partial title matches', () => {
+    const result = selectExactTitleMatchScriptUrl('My Exact Script', [
+      { name: 'My Exact Script v2', chart_url: 'https://www.tradingview.com/script/Bad999/' },
+    ])
+    expect(result).toBeNull()
+  })
+
+  it('matches title case-insensitively with trimmed whitespace', () => {
+    const result = selectExactTitleMatchScriptUrl('  My Exact Script  ', [
+      { name: 'my exact script', chart_url: 'https://www.tradingview.com/script/Trim123/' },
+    ])
+    expect(result).toBe('https://www.tradingview.com/script/Trim123/')
+  })
+
+  it('falls back to url field when chart_url is missing', () => {
+    const result = selectExactTitleMatchScriptUrl('My Exact Script', [
+      { name: 'My Exact Script', url: 'https://www.tradingview.com/script/Url456/My-Exact-Script/' },
+    ])
+    expect(result).toBe('https://www.tradingview.com/script/Url456/')
+  })
+
+  it('falls back to image_url id when chart_url and url are missing', () => {
+    const result = selectExactTitleMatchScriptUrl('My Exact Script', [
+      { name: 'My Exact Script', image_url: 'Img789' },
+    ])
+    expect(result).toBe('https://www.tradingview.com/script/Img789/')
+  })
+
+  it('resolves scripts API username from TV_SERVICE_ACCOUNT_USERNAME first', () => {
+    const result = resolveScriptsApiUsername({
+      TV_SERVICE_ACCOUNT_USERNAME: 'service-user',
+      TV_USERNAME: 'fallback-user',
+    } as NodeJS.ProcessEnv)
+    expect(result).toBe('service-user')
+  })
+
+  it('falls back to TV_USERNAME when TV_SERVICE_ACCOUNT_USERNAME is missing', () => {
+    const result = resolveScriptsApiUsername({
+      TV_USERNAME: 'main-tv-user',
+    } as NodeJS.ProcessEnv)
+    expect(result).toBe('main-tv-user')
+  })
+
+  it('returns null when both script lookup username env vars are missing', () => {
+    const result = resolveScriptsApiUsername({} as NodeJS.ProcessEnv)
+    expect(result).toBeNull()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ const config = defineConfig({
     devtools(),
     nitro({
       preset: 'node-server',
+      plugins: ['./server/plugins/pre-warm.ts'],
       rollupConfig: {
         external: ['ws', 'bufferutil', 'utf-8-validate'],
       },


### PR DESCRIPTION
## Summary
- optimize publish button detection using combined selectors with short fallbacks
- remove fixed 8s publish settle delay in warm flow and switch to event-driven settle wait
- add fast dialog pre-check to avoid expensive no-dialog scans
- wrap key warm-path page.evaluate calls with timedEvaluate to prevent long hangs
- tighten URL capture timing and API lookup timeouts in publish URL capture loop
- reduce redundant chart-context checks during publish click path

## Validation
- npm test
- npm run build

Closes #20